### PR TITLE
Revised graph encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ yarn-error.log*
 
 venv
 
-/public
+tmp

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,24 @@
+# Scripts used for development and deployment
+
+## Getting started
+
+To run the scripts, you will need Python 3.8 or later, then from the repo route:
+
+1. Create a Python virtual environment, eg, `python3 -m venv ./venv`
+2. Activate the venv, eg, `source venv/bin/activate`
+3. Pip install requiremnts, eg, `pip install -r scripts/requirements.txt`
+
+## Generating a dataset graph
+
+The current development app is hard-wired to load /dataset_graph.json (eg, public/dataset_graph.json).
+To generate that file for any given dataset (CXG or TileDB consolidated array):
+
+> $ python scripts/create*dataset_graph.py *DATASET_URI\* -o public/dataset_graph.json
+
+For example, for the full cellxgene atlas as of late March 2022:
+
+> python scripts/create_dataset_graph.py s3://czi.share-tiledb/concatenated_corpus/ -o public/dataset_graph.json
+
+Or, for a CXG in the dev bucket:
+
+> python scripts/create_dataset_graph.py s3://hosted-cellxgene-dev/fbf96dda-33f8-4b35-ae6b-9973e7413116.cxg/ -o public/dataset_graph.json

--- a/scripts/create_dataset_graph.py
+++ b/scripts/create_dataset_graph.py
@@ -1,0 +1,263 @@
+import sys
+import os
+import gzip
+import json
+import requests
+import argparse
+import datetime
+from collections import deque
+from functools import reduce
+
+import tiledb
+import pandas as pd
+
+"""
+Given reference ontologies (CL, UBERON, etc) and a baseline dataset,
+generate an annotated ontology graph for the `ontology-ui`.
+
+The graph contains:
+    * all terms used in the dataset
+    * all terms from CL, HANCESTRO, HsapDv and MmusDv
+    * and all terms reachable from those initial seed terms
+Reachable (links) is defined as:
+    * a term's ancestors
+    * any terms that the "Lattice" cross-reference links to
+
+In addition, the graph will be annotated with:
+    * term ID, label/name and ancestor
+    * synonyms from the Lattice graph
+    * dataset stats, including:
+        * number of cells in the dataset labelled with the term
+
+The cellxgene schema 2.0.0 defines conventions regarding which label categories
+are in use, and various extra-ontology annotations specific to CXG (eg, the 
+"na" term).  Per the 2.0.0 schema, we look for terms in the following columns of 
+the dataset:
+* assay_ontology_term_id
+* cell_type_ontology_term_id
+* development_stage_ontology_term_id
+* disease_ontology_term_id
+* ethnicity_ontology_term_id
+* organism_ontology_term_id
+* sex_ontology_term_id
+* tissue_ontology_term_id
+
+The code does NOT enforce or validate use of terms, ie, the dataset is presumed
+compliant with the 2.0.0 schema.
+"""
+
+# Default locators
+ALL_ONTOLOGIES_URL_DEFAULT = "https://raw.githubusercontent.com/chanzuckerberg/single-cell-curation/main/cellxgene_schema_cli/cellxgene_schema/ontology_files/all_ontology.json.gz"
+LATTICE_ONTOLOGY_URL_DEFAULT = "https://latticed-build.s3.us-west-2.amazonaws.com/ontology/ontology-2022-02-04.json"
+
+# Columns that contain terms in the CXG
+CXG_TERM_COLUMNS = [
+    "assay_ontology_term_id",
+    "cell_type_ontology_term_id",
+    "development_stage_ontology_term_id",
+    "disease_ontology_term_id",
+    "ethnicity_ontology_term_id",
+    "organism_ontology_term_id",
+    "sex_ontology_term_id",
+    "tissue_ontology_term_id",
+]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("cxg", type=str, help="CXG base URI")
+    parser.add_argument(
+        "--all-ontologies-uri",
+        type=str,
+        help="all_ontologies URI - location of all_ontologies file for cellxgene schema",
+        default=ALL_ONTOLOGIES_URL_DEFAULT,
+    )
+    parser.add_argument(
+        "--lattice-uri",
+        type=str,
+        help="lattice URI - location of Lattice term cross-reference",
+        default=LATTICE_ONTOLOGY_URL_DEFAULT,
+    )
+    parser.add_argument(
+        "-o", "--output", type=argparse.FileType("w"), default=sys.stdout
+    )
+    args = parser.parse_args()
+
+    master_ontology = make_master_ontology(args)
+    obs_df = load_obs_dataframe(args)
+    terms_directly_in_use, terms_in_use = get_terms_in_use(master_ontology, obs_df)
+
+    if args.output != sys.stdout:
+        print(
+            f"{len(terms_directly_in_use)} terms directly in use, {len(terms_in_use)} total (including ancestral terms)."
+        )
+
+    in_use_ontologies = create_in_use_ontologies(master_ontology, terms_in_use, obs_df)
+
+    result = {
+        "dataset": args.cxg,
+        "created_on": datetime.datetime.now().astimezone().isoformat(),
+        "master_ontology_uri": args.all_ontologies_uri,
+        "lattice_uri": args.lattice_uri,
+        "ontologies": in_use_ontologies,
+    }
+    json.dump(result, args.output)
+
+
+def create_in_use_ontologies(master_ontology, terms_in_use, obs_df):
+    in_use_ontologies = {
+        ont_name: {
+            term_id: term.copy()  # we will add info to term, so don't pollute master_ontology
+            for term_id, term in ontology.items()
+            if term_id in terms_in_use
+        }
+        for ont_name, ontology in master_ontology.items()
+    }
+
+    # Add stats & other annotation
+    term_counts = get_term_counts(obs_df)
+    for termId, count in term_counts.items():
+        # ignore terms that didn't make it into our in-use list, eg
+        # "unknown", "na" and other extra-ontological extensions
+        # define by the cellxgene schema
+        ontology_name = termId.split(":")[0]
+        if (
+            ontology_name in in_use_ontologies
+            and termId in in_use_ontologies[ontology_name]
+        ):
+            in_use_ontologies[ontology_name][termId]["n_cells"] = count
+
+    return in_use_ontologies
+
+
+def get_terms_in_use(master_ontology, obs_df):
+    # Seed with terms used by the dataset.
+    terms_in_use = set()
+    for col in obs_df:
+        terms_in_use.update(obs_df[col].unique())
+
+    # Silently remove known unknowns
+    terms_in_use.discard("")
+    terms_in_use.discard("na")
+    terms_in_use.discard("unknown")
+
+    # Remove and warn about unknown unknowns
+    all_legal_terms = set(
+        term_id for ont in master_ontology.values() for term_id in ont.keys()
+    )
+    unknown_terms = terms_in_use - all_legal_terms
+    if unknown_terms:
+        print("WARNING: dataset contains unknown ontology terms:")
+        print(unknown_terms)
+    terms_in_use -= unknown_terms
+
+    # save terms directly referenced by dataset
+    terms_directly_in_use = terms_in_use.copy()
+
+    # Add additional seed terms that we _always_ want to include
+    # in our ontology
+    for ont_name in ["CL", "HANCESTRO", "HsapDv", "MmusDv"]:
+        terms_in_use.update(term_id for term_id in master_ontology[ont_name].keys())
+
+    # generate list of all referenced terms, including xrefs, ancestors, etc.
+    to_be_processed = deque(terms_in_use)
+    while len(to_be_processed) > 0:
+        term = to_be_processed.popleft()
+        ontology_name = term.split(":")[0]
+        for link in ["ancestors", "xref"]:
+            linked_terms = master_ontology[ontology_name][term][link]
+            unprocessed = set(linked_terms) - terms_in_use
+            to_be_processed.extend(unprocessed)
+            terms_in_use.update(unprocessed)
+
+    return terms_directly_in_use, terms_in_use
+
+
+def get_term_counts(obs_df: pd.DataFrame) -> dict:
+    """
+    Return a dictionary of terms:counts, where counts is the
+    number of cells with that label/
+    """
+
+    def merge_counts(acc, val):
+        term, count = val
+        acc[term] = acc.get(term, 0) + count
+        return acc
+
+    term_counts = {}
+    for col in CXG_TERM_COLUMNS:
+        counts = obs_df[col].value_counts()
+        term_counts = reduce(merge_counts, counts.items(), term_counts)
+
+    return term_counts
+
+
+def make_master_ontology(args):
+    all_ontologies = fetchJson(args.all_ontologies_uri)
+    lattice = fetchJson(args.lattice_uri)
+    all_terms = set(
+        term_id for ont in all_ontologies.values() for term_id in ont.keys()
+    )
+
+    # Consolidated ontologies with xref from lattice
+    for _, ont in all_ontologies.items():
+        for id, node in ont.items():
+            if id in lattice:
+                # Prune xrefs already in the ancestor list.
+                xref = set(lattice[id].get("ancestors", [])) - set(node["ancestors"])
+                # Prune terms not in our ontologies (this can happen if Lattice was built
+                # on a more recent version of the ontology).
+                xref &= all_terms
+                node["xref"] = list(xref)
+                # de-dup, as Lattice occasionally has duplicate terms
+                node["synonyms"] = list(set(lattice[id].get("synonyms", [])))
+            else:
+                node["xref"] = []
+                node["synonyms"] = []
+
+    return all_ontologies
+
+
+def fetchJson(url: str) -> dict:
+    response = requests.get(url)
+    if not response.ok:
+        return None
+    if response.headers["Content-Type"] == "application/octet-stream" or url.endswith(
+        ".gz"
+    ):
+        return json.loads(gzip.decompress(response.content))
+    return response.json()
+
+
+def load_obs_dataframe(args):
+    with tiledb.open(
+        f"{args.cxg}/obs",
+        "r",
+        config={"vfs.s3.region": os.environ.get("AWS_DEFAULT_REGION", "us-west-2")},
+    ) as arr:
+        # split col into dims and attrs as required by tiledb query API
+        dim_names = set(d.name for d in arr.schema.domain)
+        obs = arr.query(
+            dims=[c for c in CXG_TERM_COLUMNS if c in dim_names],
+            attrs=[c for c in CXG_TERM_COLUMNS if c not in dim_names],
+        ).df[:]
+
+    """
+    The tissue_ontology_term_id and the assay_ontology_term_id columns may contain auxilliary information
+    encoded in a term suffix, eg, "CL:0000000 (foobar)". For more detail see:
+    https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/2.0.0/schema.md#tissue_ontology_term_id
+    and
+    https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/2.0.0/schema.md#assay_ontology_term_id
+
+    This code removes the extra annotation from _all_ term columns.
+    """
+    pat = r"(?P<term>^.+:\S+)(?:\s\(.*\))?$"
+    repl = lambda m: m.group("term")
+    for col in obs:
+        obs[col] = obs[col].str.replace(pat, repl, regex=True)
+
+    return obs
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+tiledb
+pandas
+pyarrow
+requests

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,63 +3,35 @@ import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import { Helmet } from "react-helmet";
 
 import Vertex from "./components/Vertex";
-import Dag, { OntologyVertexDatum } from "./components/OntologyExplorer";
+import Dag from "./components/OntologyExplorer";
 import ThreeOntology from "./components/ThreeOntology";
 import DiscoveryLog from "./components/DiscoveryLog";
-import load from "./util/load";
-import { ILatticeOntology, ILatticeTerm, IOntology, IVertex } from "./d";
+import loadDatasetGraph from "./util/loadDatasetGraph";
+import { DatasetGraph, Ontology } from "./d";
 
 interface IProps {}
 
 interface IState {
-  cl_ontology?: IOntology;
-  mondo_ontology?: IOntology;
-  uberon_ontology?: IOntology;
-  lattice?: ILatticeOntology;
+  graph?: DatasetGraph;
+  lattice?: Ontology;
 }
-
-type AllOntologies = {
-  EFO: Record<string, IVertex>;
-  HANCESTRO: Record<string, IVertex>;
-  CL: Record<string, IVertex>;
-  HsapDv: Record<string, IVertex>;
-  PATO: Record<string, IVertex>;
-  NCBITaxon: Record<string, IVertex>;
-  MmusDv: Record<string, IVertex>;
-  MONDO: Record<string, IVertex>;
-  UBERON: Record<string, IVertex>;
-};
 
 class App extends React.Component<IProps, IState> {
   constructor(props: IProps) {
     super(props);
     this.state = {
-      cl_ontology: undefined,
-      mondo_ontology: undefined,
-      uberon_ontology: undefined,
+      graph: undefined,
       lattice: undefined,
     };
   }
 
   async componentDidMount() {
-    const _o: AllOntologies = await load(
-      "/all_ontology.json"
-    );
-    const _lattice = await load("/lattice.json");
-
-    /* make a map of the ontology values for easy getting and setting */
-    let cl_ontology = new Map(Object.entries(_o.CL));
-    let mondo_ontology = new Map(Object.entries(_o.MONDO));
-    let uberon_ontology = new Map(Object.entries(_o.UBERON));
-    let lattice = new Map(Object.entries<ILatticeTerm>(_lattice));
-
-    this.setState({ cl_ontology, mondo_ontology, uberon_ontology, lattice });
+    const [graph, lattice] = await loadDatasetGraph("/dataset_graph.json");
+    this.setState({ graph, lattice });
   }
 
   render() {
-    const { cl_ontology, mondo_ontology, uberon_ontology, lattice } =
-      this.state;
-
+    const { graph, lattice } = this.state;
     return (
       <Router>
         <div
@@ -70,13 +42,13 @@ class App extends React.Component<IProps, IState> {
             color: "#555",
           }}
         >
-          {!cl_ontology && "Loading..."}
+          {!graph && "Loading..."}
           <Helmet>
             <meta charSet="utf-8" />
             <title>Cell Ontology</title>
           </Helmet>
 
-          {cl_ontology && mondo_ontology && uberon_ontology && lattice && (
+          {graph && lattice && (
             <Switch>
               <Route
                 path="/cell/ontology"
@@ -84,9 +56,9 @@ class App extends React.Component<IProps, IState> {
                   return (
                     <Dag
                       ontologyName="cl"
-                      ontology={cl_ontology}
+                      ontology={graph.ontologies.CL}
                       lattice={lattice}
-                      uberon={uberon_ontology}
+                      uberon={graph.ontologies.UBERON}
                     />
                   );
                 }}
@@ -95,7 +67,10 @@ class App extends React.Component<IProps, IState> {
                 path="/cell/three"
                 render={({ match }) => {
                   return (
-                    <ThreeOntology ontologyName="cl" ontology={cl_ontology} />
+                    <ThreeOntology
+                      ontologyName="cl"
+                      ontology={graph.ontologies.CL}
+                    />
                   );
                 }}
               />
@@ -105,8 +80,8 @@ class App extends React.Component<IProps, IState> {
                   return (
                     <Vertex
                       ontologyName="cl"
-                      ontology={cl_ontology}
-                      vertex={cl_ontology.get(match.params.vertex)}
+                      ontology={graph.ontologies.CL}
+                      vertex={graph.ontologies.CL.get(match.params.vertex)}
                       vertexID={match.params.vertex}
                       lattice={lattice}
                     />
@@ -119,9 +94,9 @@ class App extends React.Component<IProps, IState> {
                   return (
                     <Dag
                       ontologyName="mondo"
-                      ontology={mondo_ontology}
+                      ontology={graph.ontologies.MONDO}
                       lattice={lattice}
-                      uberon={uberon_ontology}
+                      uberon={graph.ontologies.UBERON}
                     />
                   );
                 }}
@@ -132,8 +107,8 @@ class App extends React.Component<IProps, IState> {
                   return (
                     <Vertex
                       ontologyName="mondo"
-                      ontology={mondo_ontology}
-                      vertex={mondo_ontology.get(match.params.vertex)}
+                      ontology={graph.ontologies.MONDO}
+                      vertex={graph.ontologies.MONDO.get(match.params.vertex)}
                       vertexID={match.params.vertex}
                       lattice={lattice}
                     />
@@ -146,9 +121,9 @@ class App extends React.Component<IProps, IState> {
                   return (
                     <Dag
                       ontologyName="uberon"
-                      ontology={uberon_ontology}
+                      ontology={graph.ontologies.UBERON}
                       lattice={lattice}
-                      uberon={uberon_ontology}
+                      uberon={graph.ontologies.UBERON}
                     />
                   );
                 }}
@@ -159,8 +134,8 @@ class App extends React.Component<IProps, IState> {
                   return (
                     <Vertex
                       ontologyName="uberon"
-                      ontology={uberon_ontology}
-                      vertex={uberon_ontology.get(match.params.vertex)}
+                      ontology={graph.ontologies.UBERON}
+                      vertex={graph.ontologies.UBERON.get(match.params.vertex)}
                       vertexID={match.params.vertex}
                       lattice={lattice}
                     />

--- a/src/components/OntologyExplorer/Controls.tsx
+++ b/src/components/OntologyExplorer/Controls.tsx
@@ -1,23 +1,10 @@
 import React from "react";
-import emoji from "react-easy-emoji";
 
-import { majorCompartments } from "../../majorCompartments";
-
-import { IOntology, IVertex } from "../../d";
-
+import { Ontology, OntologyTerm } from "../../d";
 import {
   Button,
   Classes,
-  Code,
-  Divider,
   Drawer,
-  DrawerSize,
-  H5,
-  HTMLSelect,
-  OptionProps,
-  Label,
-  Position,
-  Switch,
   RadioGroup,
   Radio,
   InputGroup,
@@ -27,7 +14,6 @@ import {
 import { OntologyVertexDatum } from ".";
 
 import {
-  IItemRendererProps,
   ItemRenderer,
   ItemPredicate,
   Omnibar,
@@ -40,7 +26,7 @@ interface IProps {
   menubarHeight: number;
   isSubset: boolean;
   outdegreeCutoffNodes: number;
-  uberon: null | IOntology;
+  uberon: null | Ontology;
   handleDagSearchChange: any;
   subsetToNode: any;
   resetSubset: any;
@@ -83,7 +69,7 @@ class OntologyExplorer extends React.Component<IProps, IState> {
     const { uberon } = this.props;
     const _uberonVerticesAsArray: ICompartmentOmnibarItem[] = [];
 
-    uberon?.forEach((v: IVertex, id) => {
+    uberon?.forEach((v: OntologyTerm, id) => {
       _uberonVerticesAsArray.push({ uberonID: id, label: v.label });
     });
 
@@ -107,8 +93,6 @@ class OntologyExplorer extends React.Component<IProps, IState> {
       simulationRunning,
       menubarHeight,
       isSubset,
-      outdegreeCutoffNodes,
-      uberon,
       handleDagSearchChange,
       subsetToNode,
       resetSubset,
@@ -381,7 +365,7 @@ class OntologyExplorer extends React.Component<IProps, IState> {
   };
 
   escapeRegExpChars = (text: string) => {
-    return text.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+    return text.replace(/([.*+?^=!:${}()|[\]/\\])/g, "\\$1");
   };
 
   filterCompartment: ItemPredicate<ICompartmentOmnibarItem> = (

--- a/src/components/OntologyExplorer/Sugiyama.tsx
+++ b/src/components/OntologyExplorer/Sugiyama.tsx
@@ -1,29 +1,14 @@
-import React, { createRef } from "react";
+import React from "react";
 
-import {
-  dagConnect,
-  sugiyama,
-  layeringSimplex,
-  layeringLongestPath,
-  layeringCoffmanGraham,
-  decrossOpt,
-  twolayerOpt,
-  decrossTwoLayer,
-  coordQuad,
-  coordGreedy,
-  coordCenter,
-  Dag,
-  dagStratify,
-} from "d3-dag/dist";
+import { sugiyama, Dag, dagStratify } from "d3-dag/dist";
 
-import { symbolTriangle, symbol, line, curveCatmullRom } from "d3-shape";
-import { interpolateRainbow } from "d3-scale-chromatic";
+import { line, curveCatmullRom } from "d3-shape";
 
-import { IOntology, IVertex } from "../../d";
+import { Ontology } from "../../d";
 
 interface IProps {
   sugiyamaStratifyData: any;
-  ontology: IOntology;
+  ontology: Ontology;
 }
 
 interface IState {
@@ -57,37 +42,11 @@ class Sugiyama extends React.Component<IProps, IState> {
 
   setup = () => {
     const { sugiyamaStratifyData } = this.props;
-    const { nodeRadius } = this.state;
-
-    /**
-     * d3-dag options
-     */
-    const layerings = {
-      "Simplex (slow)": layeringSimplex(),
-      "Longest Path (fast)": layeringLongestPath(),
-      "Coffman Graham (medium)": layeringCoffmanGraham(),
-    };
-
-    const decrossings = {
-      "Optimal (slow)": decrossOpt(),
-      "Two Layer Opt (medium)": decrossTwoLayer().order(twolayerOpt()),
-      "Two Layer (fast)": decrossTwoLayer(),
-    };
-
-    const coords = {
-      "Quad (slow)": coordQuad(),
-      "Greedy (medium)": coordGreedy(),
-      "Center (fast)": coordCenter(),
-    };
 
     /**
      * Initialize d3-dag layout operator
      */
     const _sugiyamaLayout = sugiyama();
-    // .layering(layerings["Simplex (slow)"])
-    // .decross(decrossings["Two Layer (fast)"])
-    // .coord(coords["Quad (slow)"])
-    // .nodeSize(() => [nodeRadius * 2 * 1.5, nodeRadius * 2 * 1.5]);
 
     /**
      * Initialize stratify data operator
@@ -110,10 +69,6 @@ class Sugiyama extends React.Component<IProps, IState> {
     /**
      * scale multiplier, sugiyama returns small numbers it seems, between 0 and 10
      */
-
-    const arrow = symbol()
-      .type(symbolTriangle)
-      .size((nodeRadius * nodeRadius) / 5.0);
 
     this.setState({
       dag,

--- a/src/components/OntologyExplorer/drawForce/hulls.ts
+++ b/src/components/OntologyExplorer/drawForce/hulls.ts
@@ -1,17 +1,16 @@
-import { polygonHull, polygonCentroid } from "d3-polygon";
+import { polygonHull } from "d3-polygon";
 
-import { IOntology } from "../../../d";
+import { Ontology } from "../../../d";
 
 import { interpolateSinebow } from "d3-scale-chromatic";
 import { color } from "d3-color";
 import { scaleLinear } from "d3-scale";
-import { arrayLengthCompare } from "@blueprintjs/core/lib/esm/common/utils";
 
 /**
  * Draw all hulls
  */
 export const drawHulls = (
-  ontology: IOntology,
+  ontology: Ontology,
   nodes: any,
   context: any,
   hullBorderColor: string,
@@ -21,9 +20,6 @@ export const drawHulls = (
   /**
    * GIVEN ALL PRIOR FILTERED NODES
    */
-  // filteredVerticesForHulls.forEach((vertex_id, i) => {
-  //   drawHull(vertex_id);
-  // });
   /**
    * CUSTOM SUBSET FOR TEST
    */
@@ -47,7 +43,7 @@ export const drawHulls = (
  */
 const drawHull = (
   vertex_id: string,
-  ontology: IOntology,
+  ontology: Ontology,
   nodes: any,
   context: any,
   hullBorderColor: string,
@@ -85,7 +81,6 @@ const drawHull = (
   });
 
   const hull = polygonHull(points);
-  const centroid = polygonCentroid(points);
 
   if (hull) {
     /**
@@ -106,19 +101,5 @@ const drawHull = (
     context.lineWidth = 0;
     context.strokeStyle = hullColor;
     context.stroke();
-
-    /**
-     * Text on centroid of hull
-     */
-    // context.fillStyle = hullLabelColor;
-    // context.font = "18px helvetica";
-    // context.fillText(
-    //   `${vertex.label}`, //${vertex_id}`
-    //   /**
-    //    * subtract some width to center text
-    //    */
-    //   centroid[0],
-    //   centroid[1]
-    // );
   }
 };

--- a/src/components/OntologyExplorer/drawForce/index.ts
+++ b/src/components/OntologyExplorer/drawForce/index.ts
@@ -12,7 +12,7 @@ import { select } from "d3-selection";
 import { interpolateSinebow } from "d3-scale-chromatic";
 
 import { OntologyVertexDatum } from "..";
-import { IOntology } from "../../../d";
+import { Ontology, OntologyTerm } from "../../../d";
 
 import { drawHulls } from "./hulls";
 
@@ -31,13 +31,13 @@ export const drawForceDag = (
   scaleFactor: number,
   translateCenter: number,
   dagCanvasRef: React.RefObject<HTMLCanvasElement>,
-  ontology: IOntology,
+  ontology: Ontology,
   setHoverNode: (node: OntologyVertexDatum | undefined) => void,
   setPinnedNode: (node: OntologyVertexDatum | undefined) => void,
   incrementRenderCounter: any,
   onForceSimulationEnd: any,
   hullsTurnedOn: boolean,
-  _latticeCL: any,
+  lattice: any,
   compartment: string | null,
   highlightAncestors: boolean,
   showTabulaSapiensDataset: boolean
@@ -245,10 +245,9 @@ export const drawForceDag = (
         /**
          * check compartment distribution in ontology
          */
-        if (_latticeCL && compartment) {
-          const celltype_is_in_compartment = _latticeCL
-            .get(node.id)
-            .ancestors.includes(compartment);
+        if (lattice && compartment) {
+          const term: OntologyTerm = lattice.get(node.id);
+          const celltype_is_in_compartment = term.xref.includes(compartment);
           if (celltype_is_in_compartment) {
             context.fillStyle = "orange";
           }

--- a/src/components/OntologyExplorer/index.tsx
+++ b/src/components/OntologyExplorer/index.tsx
@@ -9,7 +9,8 @@ import Vertex from "../Vertex";
 import Sugiyama from "./Sugiyama";
 import Controls from "./Controls";
 
-import { ILatticeOntology, IOntology, IVertex } from "../../d";
+// import { ILatticeOntology, IOntology, IVertex } from "../../d";
+import { Ontology, OntologyTerm } from "../../d";
 
 export interface OntologyVertexDatum extends SimulationNodeDatum {
   id: string;
@@ -19,9 +20,9 @@ export interface OntologyVertexDatum extends SimulationNodeDatum {
 
 interface IProps {
   ontologyName: string;
-  ontology: IOntology;
-  lattice: ILatticeOntology;
-  uberon: IOntology;
+  ontology: Ontology;
+  lattice: Ontology;
+  uberon: Ontology;
 }
 
 interface IState {
@@ -156,20 +157,6 @@ class OntologyExplorer extends React.Component<IProps, IState> {
         v.label.includes("fungal") ||
         v.label.includes("spore");
 
-      const bigTroublesomeMetadataCells = // unify the above with this list
-        id === "CL:0000988" || // hematopoietic cell
-        id === "CL:0000393" || // electrically active
-        id === "CL:0000219" || // motile cell
-        id === "CL:0002371" || // somatic cell
-        id === "CL:0000066" || // epithelial cell
-        id === "CL:0000000" || // cell
-        id === "CL:0000325" || // stuff accumulating cell
-        id === "CL:0000151" || // secratory cell
-        id === "CL:0000548" || // animal cell
-        id === "CL:0000234" || // phagocyte
-        id === "CL:0002319" || // neural cell
-        id === "CL:0000003"; // native cell
-
       if (
         v.descendants.length > maximumOutdegree || // more than n descendants ... sometimes we want to remove the nodes, sometimes we want to xyz the links
         v.descendants.length < minimumOutdegree || // remove nodes with less than n descendants ... sometimes we want to start at cell and show the big stuff only
@@ -204,7 +191,7 @@ class OntologyExplorer extends React.Component<IProps, IState> {
   initializeCanvasRenderer = (
     nodes: OntologyVertexDatum[],
     links: SimulationLinkDatum<any>[],
-    ontology: IOntology
+    ontology: Ontology
   ) => {
     const {
       forceCanvasWidth,
@@ -218,14 +205,6 @@ class OntologyExplorer extends React.Component<IProps, IState> {
     } = this.state;
 
     const { lattice } = this.props;
-
-    const _latticeCL = new Map();
-
-    lattice?.forEach((value: any, key: any) => {
-      if (key.includes("CL")) {
-        _latticeCL.set(key, value);
-      }
-    });
 
     const redrawCanvas = drawForceDag(
       nodes, // todo, mutates
@@ -241,7 +220,7 @@ class OntologyExplorer extends React.Component<IProps, IState> {
       this.incrementRenderCounter,
       this.onForceSimulationEnd,
       hullsEnabled,
-      _latticeCL,
+      lattice,
       compartment,
       highlightAncestors,
       showTabulaSapiensDataset
@@ -276,10 +255,10 @@ class OntologyExplorer extends React.Component<IProps, IState> {
       showTabulaSapiensDataset,
     } = this.state;
 
-    const hoverVertex: IVertex | undefined =
+    const hoverVertex: OntologyTerm | undefined =
       hoverNode && ontology.get(hoverNode.id);
 
-    const pinnedVertex: IVertex | undefined =
+    const pinnedVertex: OntologyTerm | undefined =
       pinnedNode && ontology.get(pinnedNode.id);
 
     return (

--- a/src/components/ThreeOntology.tsx
+++ b/src/components/ThreeOntology.tsx
@@ -1,17 +1,11 @@
 import React, { createRef } from "react";
-import { forceSimulation, forceCollide } from "d3-force-3d";
 import ForceGraph3D from "3d-force-graph";
-import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
-import { BokehPass } from "three/examples/jsm/postprocessing/BokehPass.js";
-import SpriteText from "three-spritetext";
-import Three from "three";
 
-import { IOntology, IVertex } from "../d";
+import { Ontology } from "../d";
 import { createNodesLinksHulls } from "../util/createNodesLinksHulls";
-import Vertex from "./Vertex";
 
 interface IProps {
-  ontology: IOntology;
+  ontology: Ontology;
   ontologyName: string;
 }
 interface IState {
@@ -89,12 +83,6 @@ class ThreeOntology extends React.Component<IProps, IState> {
     Graph.backgroundColor("white");
 
     /**
-     * Store the scene and camera for other consumers
-     */
-    const scene = Graph.scene();
-    const camera = Graph.camera();
-
-    /**
      * Render text on nodes
      */
     Graph.nodeLabel((d: any) => {
@@ -113,8 +101,6 @@ class ThreeOntology extends React.Component<IProps, IState> {
     /**
      * Link direction particles
      */
-    // Graph.linkDirectionalParticles(2);
-
     Graph.onNodeClick((node: any) => {
       // Aim at node from outside it
       const distance = 40;
@@ -126,20 +112,6 @@ class ThreeOntology extends React.Component<IProps, IState> {
         3000 // ms transition duration
       );
     });
-
-    /**
-     * Postprocessing
-     */
-
-    // const bloomPass = new UnrealBloomPass();
-    // bloomPass.strength = 3;
-    // bloomPass.radius = 1;
-    // bloomPass.threshold = 0.1;
-    //   .addPass(bloomPass);
-
-    const bokehParams = { focus: 500, aperture: 0.01, maxblur: 0.01 }; // maxBlur .001 to turn back on
-    const bokehPass = new BokehPass(scene, camera, bokehParams);
-    // Graph.postProcessingComposer().addPass(bokehPass);
   };
 
   render() {

--- a/src/components/Vertex.tsx
+++ b/src/components/Vertex.tsx
@@ -1,20 +1,13 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import fetchEBITerm from "../util/fetchEBITerm";
-import {
-  IEBITerm,
-  IEBITermAPIResponse,
-  ILatticeOntology,
-  ILatticeTerm,
-  IOntology,
-  IVertex,
-} from "../d";
+import { IEBITerm, IEBITermAPIResponse, Ontology, OntologyTerm } from "../d";
 
 interface IProps {
   ontologyName: string;
-  ontology: IOntology;
-  lattice: ILatticeOntology;
-  vertex: IVertex | undefined;
+  ontology: Ontology;
+  lattice: Ontology;
+  vertex: OntologyTerm | undefined;
   vertexID: string;
 }
 
@@ -68,7 +61,7 @@ class Vertex extends React.Component<IProps, IState> {
       term && term.annotation.definition && term.annotation.definition[0];
 
     /* UBERON compartment linkage, if present */
-    const _lattice: ILatticeTerm | undefined = lattice.get(vertexID);
+    const _lattice: OntologyTerm | undefined = lattice.get(vertexID);
 
     let _filteredLattice: string[] | null = null;
 
@@ -90,12 +83,12 @@ class Vertex extends React.Component<IProps, IState> {
         <ol>
           {vertex &&
             vertex.ancestors.map((ancestor: string) => {
-              const _a: IVertex | undefined = ontology.get(ancestor);
+              const _a: OntologyTerm | undefined = ontology.get(ancestor);
               if (!_a || !_a.label) {
                 console.log(
                   "In vertex.tsx, while rendering ancestors, ontology.get failed to return a vertex, possible bad ID"
                 );
-                return;
+                return null;
               }
               return (
                 <li key={ancestor}>
@@ -114,7 +107,7 @@ class Vertex extends React.Component<IProps, IState> {
                 console.log(
                   "In vertex.tsx, while rendering descendents, ontology.get failed to return a vertex, possible bad ID"
                 );
-                return;
+                return null;
               }
               return (
                 <li key={descendant}>
@@ -128,16 +121,16 @@ class Vertex extends React.Component<IProps, IState> {
         <ol>
           {_filteredLattice &&
             _filteredLattice.map((uberonID: string) => {
-              const _u: ILatticeTerm | undefined = lattice.get(uberonID);
-              if (!_u || !_u.name) {
+              const _u: OntologyTerm | undefined = lattice.get(uberonID);
+              if (!_u || !_u.label) {
                 console.log(
                   "In vertex.tsx, while rendering lattice uberon compartments, lattice.get failed to return a vertex, possible bad ID"
                 );
-                return;
+                return null;
               }
               return (
-                <li key={_u.name}>
-                  <Link to={`/compartment/${uberonID}`}> {_u.name} </Link>
+                <li key={uberonID}>
+                  <Link to={`/compartment/${uberonID}`}> {_u.label} </Link>
                 </li>
               );
             })}

--- a/src/components/Vertex.tsx
+++ b/src/components/Vertex.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import fetchEBITerm from "../util/fetchEBITerm";
-import { IEBITerm, IEBITermAPIResponse, Ontology, OntologyTerm } from "../d";
+import { EBITerm, EBITermAPIResponse, Ontology, OntologyTerm } from "../d";
 
 interface IProps {
   ontologyName: string;
@@ -12,7 +12,7 @@ interface IProps {
 }
 
 interface IState {
-  term: null | IEBITerm;
+  term: null | EBITerm;
 }
 
 class Vertex extends React.Component<IProps, IState> {
@@ -35,14 +35,14 @@ class Vertex extends React.Component<IProps, IState> {
 
   doGetEBITerm = async () => {
     const { vertexID, ontologyName } = this.props;
-    let _ebiResponse: IEBITermAPIResponse;
+    let _ebiResponse: EBITermAPIResponse;
     try {
       // call the ebi api
       _ebiResponse = await fetchEBITerm(vertexID);
       // filter down the terms to the ontology we're in
       // this call returns every ontology the term appears in
-      const term: IEBITerm = _ebiResponse._embedded.terms.filter(
-        (term: IEBITerm) => {
+      const term: EBITerm = _ebiResponse._embedded.terms.filter(
+        (term: EBITerm) => {
           return term.ontology_name === ontologyName; /* ie., === cl */
         }
       )[0];

--- a/src/d.ts
+++ b/src/d.ts
@@ -44,7 +44,7 @@ export interface DatasetGraph {
   ontologies: Record<OntologyName, Ontology>;
 }
 
-export interface IEBITerm {
+export interface EBITerm {
   annotation: {
     created_by: string[];
     creation_date: string[];
@@ -76,20 +76,20 @@ export interface IEBITerm {
   _links: any;
 }
 
-export interface IEBITermAPIResponse {
-  page: IEBITermPage;
-  _embedded: IEBITermEmbedded;
-  _links: IEBITermLinks;
+export interface EBITermAPIResponse {
+  page: EBITermPage;
+  _embedded: EBITermEmbedded;
+  _links: EBITermLinks;
 }
 
-interface IEBITermPage {
+interface EBITermPage {
   size: number;
   totalElements: number;
   totalPages: number;
   number: number;
 }
 
-interface IEBITermLinks {
+interface EBITermLinks {
   self: { href: string };
   first: { href: string };
   prev: { href: string };
@@ -97,6 +97,6 @@ interface IEBITermLinks {
   last: { href: string };
 }
 
-export interface IEBITermEmbedded {
-  terms: IEBITerm[];
+export interface EBITermEmbedded {
+  terms: EBITerm[];
 }

--- a/src/d.ts
+++ b/src/d.ts
@@ -1,19 +1,47 @@
 // This is the entire CL ontology converted to JavaScript map type
-export type IOntology = Map<string, IVertex>;
+// export type IOntology = Map<string, IVertex>;
 
-export type ILatticeOntology = Map<string, ILatticeTerm>;
+// export type ILatticeOntology = Map<string, ILatticeTerm>;
 
-export interface ILatticeTerm {
-  name: string;
-  ancestors: string[];
-  synonyms: string[];
-}
+// export interface ILatticeTerm {
+//   name: string;
+//   ancestors: string[];
+//   synonyms: string[];
+// }
 
-export interface IVertex {
-  label: string;
+// export interface IVertex {
+//   label: string;
+//   deprecated: boolean;
+//   ancestors: string[];
+//   descendants: string[];
+// }
+
+export type OntologyName = string; // eg "CL"
+export type OntologyId = string; // eg "CL:000000"
+export interface OntologyTerm {
+  id: OntologyId; // eg, CL:0000000
+  label: string; // eg, "heart cell"
   deprecated: boolean;
-  ancestors: string[];
-  descendants: string[];
+  ancestors: OntologyId[]; // ancestor terms -- within the same ontology
+  descendants: OntologyId[];
+  xref: OntologyId[]; // cross-ref & related terms - in this and other ontologies (includes ancestors).
+  synonyms: string[];
+
+  // Statistics & information from the dataset
+  n_cells: number; // number of cells labelled with this term
+}
+export type Ontology = Map<OntologyId, OntologyTerm>;
+
+/**
+ * The ontologies used in a dataset, annotated with summary information
+ * about the dataset.
+ */
+export interface DatasetGraph {
+  dataset: string;
+  created_on: string; // ISO8601 DateTime
+  master_ontology_uri: string; // source of master (full) ontology
+  lattice_uri: string; // source of xref lattice data
+  ontologies: Record<OntologyName, Ontology>;
 }
 
 export interface IEBITerm {

--- a/src/util/createNodesLinksHulls.ts
+++ b/src/util/createNodesLinksHulls.ts
@@ -1,11 +1,10 @@
-import { NodeDatum } from "d3-dag/dist/sugiyama/utils";
 import { SimulationLinkDatum } from "d3-force";
 import { OntologyVertexDatum } from "../components/OntologyExplorer";
 
-import { IOntology, IVertex } from "../d";
+import { Ontology, OntologyTerm } from "../d";
 
 export const createNodesLinksHulls = (
-  ontology: IOntology,
+  ontology: Ontology,
   nodesToFilter: string[],
   outdegreeCutoff: number,
   doCreateSugiyamaDatastructure: boolean,
@@ -15,7 +14,7 @@ export const createNodesLinksHulls = (
   const links: { source: string; target: string }[] = [];
   const sugiyamaStratifyData: { id: string; parentIds: string[] }[] = [];
 
-  ontology.forEach((vertex: IVertex, vertexID: string) => {
+  ontology.forEach((vertex: OntologyTerm, vertexID: string) => {
     /**
      * If there's a subtree, and the vertex exists in it, push it.
      */
@@ -84,10 +83,10 @@ export const createNodesLinksHulls = (
      * if a and b both have links to e, the condition is met, and same for b and c both having links to e
      * so this may be enough
      */
-    const parentVertex: IVertex | undefined = ontology.get(l.source);
+    const parentVertex: OntologyTerm | undefined = ontology.get(l.source);
     if (parentVertex && parentVertex.descendants.length > outdegreeCutoff)
       parentVertex.descendants.forEach((descendantID: string) => {
-        const descendantVertex: IVertex | undefined =
+        const descendantVertex: OntologyTerm | undefined =
           ontology.get(descendantID);
 
         // check if these descendants have in their own descendants members of parentVertex.descendants

--- a/src/util/loadDatasetGraph.ts
+++ b/src/util/loadDatasetGraph.ts
@@ -1,0 +1,71 @@
+import load from "./load";
+import { DatasetGraph, Ontology, OntologyName } from "../d";
+
+/**
+ * Load and initialize the dataset graph from the given URI.
+ *
+ * @param url - the location of the raw graph
+ * @returns [graph: DatasetGraph, lattice: Ontology]
+ */
+export default async function loadDatasetGraph(
+  url: string
+): Promise<[DatasetGraph, Ontology]> {
+  const rawGraph = await load("/dataset_graph.json");
+  const datasetGraph: DatasetGraph = createDatasetGraph(rawGraph);
+  const lattice: Ontology = createLattice(datasetGraph);
+  return [datasetGraph, lattice];
+}
+
+/**
+ * Create the lattice -- the flattened map of all terms, used
+ * for quick & easy search.
+ */
+function createLattice(datasetGraph: DatasetGraph): Ontology {
+  return new Map(
+    (function* () {
+      for (const ontology of Object.values(datasetGraph.ontologies)) {
+        yield* ontology;
+      }
+    })()
+  );
+}
+
+/**
+ * Create the DatasetGraph for internal use, from the raw graph provided
+ * by the OTA service.  Transformations performed:
+ *  * Each ontology is saved as a Map object
+ *  * For each OntologyTerm:
+ *    * add the ID to the object (so it can be used independent of the ontology)
+ *    * ancestors is merged into .xref to make search simpler.
+ *    * add descendants
+ */
+function createDatasetGraph(rawGraph: any): DatasetGraph {
+  // Convert each ontology from Object to Map
+  const datasetGraph: DatasetGraph = {
+    ...rawGraph,
+    ontologies: Object.fromEntries(
+      Object.keys(rawGraph.ontologies).map((key: OntologyName) => [
+        key,
+        new Map(Object.entries(rawGraph.ontologies[key])),
+      ])
+    ),
+  };
+
+  // Add ID, descendants and merge ancestors into xref
+  for (const ontology of Object.values(datasetGraph.ontologies)) {
+    for (const [termId, term] of ontology.entries()) {
+      term.id = termId;
+      term.descendants = term.descendants || [];
+      term.xref = [...new Set(term.xref.concat(term.ancestors))];
+
+      for (const ancestorId of term.ancestors) {
+        const ancestor = ontology.get(ancestorId);
+        if (!ancestor) continue;
+        if (ancestor.descendants === undefined) ancestor.descendants = [];
+        ancestor.descendants.push(termId);
+      }
+    }
+  }
+
+  return datasetGraph;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
Multiple changes:
1. obsoleted lattice and all_ontologies, replacing with a unified graph
2. added a script to generate the graph for any given (actual) CXG dataset
3. ported app to the new data model
4. cleanup - dead code and naming
5. Updated tsconfig to target ES6/ES2015 so we can use generators