### PR TITLE
Search in right sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@blueprintjs/core": "^4.2.0",
+        "@blueprintjs/popover2": "^1.1.4",
         "@blueprintjs/select": "^4.1.3",
         "@craco/craco": "^7.0.0-alpha.3",
         "@react-hook/window-size": "^3.0.7",
@@ -1883,17 +1884,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@blueprintjs/colors": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/colors/-/colors-4.1.0.tgz",
-      "integrity": "sha512-aXgkEBg2oEz6lCE/sidvREUzQF7eJq2R8BvfOcQ1ICV4r/KVFszee6seA12ZtVaphfvuR4EE/raH6F1d0f4y7g=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/colors/-/colors-4.1.1.tgz",
+      "integrity": "sha512-uA/TDvIOG/TJ+mDJNerFRK5WnUJlInbRshzHI5SbJXlaPXXIj5BMxAXB67izH0gjvSNj5cXy/9UIgTO2WCB7XA=="
     },
     "node_modules/@blueprintjs/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-/bQN8mukY6VdeB1Bv2j/GQmJILe+drTNT4cO958QwGvPaJWLLD2Z/XdfTj8ffoWtYMrDLvVKkXKHt99gOnlUJQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-4.2.1.tgz",
+      "integrity": "sha512-hd5kiPzyicfqYsapMiNRG2SNQGJK+pkJH914xODVBmF0SK4jnmZk1cCEjhNfp9ibjxHxOCZsxAU7Gy8NgAonyw==",
       "dependencies": {
-        "@blueprintjs/colors": "^4.1.0",
-        "@blueprintjs/icons": "^4.2.3",
+        "@blueprintjs/colors": "^4.1.1",
+        "@blueprintjs/icons": "^4.2.4",
         "@juggle/resize-observer": "^3.3.1",
         "@types/dom4": "^2.0.1",
         "classnames": "^2.2",
@@ -1914,13 +1915,43 @@
       }
     },
     "node_modules/@blueprintjs/icons": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-4.2.3.tgz",
-      "integrity": "sha512-6xPneQo7bCkO96q9zOhXVh7/6QkIb8weHIwH5uyt5rmvq9/QTYcw0T2hOKiqqmDCvzv5OlZpY9QC+8deKVWWpQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-4.2.4.tgz",
+      "integrity": "sha512-dbRoAmh4SCQGCuIgMmxYHcAknW9MIhASYbvlzSPR6fV9poewuMemzTQMLiLT8Ztvigb7YwkBZjDSDF3yq6s5uw==",
       "dependencies": {
         "change-case": "^4.1.2",
         "classnames": "^2.2",
         "tslib": "~2.3.1"
+      }
+    },
+    "node_modules/@blueprintjs/popover2": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/popover2/-/popover2-1.1.4.tgz",
+      "integrity": "sha512-waco9U5IDlZ+1zYTZK7eC/TLH8IFhKEAMUrt0hVQw4au6Chb+edyWOXhuvopmR/akR0wTTX8kgaptxJ+zmAxvg==",
+      "dependencies": {
+        "@blueprintjs/core": "^4.2.1",
+        "@juggle/resize-observer": "^3.3.1",
+        "@popperjs/core": "^2.5.4",
+        "classnames": "^2.2",
+        "dom4": "^2.1.5",
+        "react-popper": "^2.2.4",
+        "tslib": "~2.3.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || 17 || 18"
+      }
+    },
+    "node_modules/@blueprintjs/popover2/node_modules/react-popper": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17"
       }
     },
     "node_modules/@blueprintjs/select": {
@@ -3427,6 +3458,15 @@
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@react-hook/debounce": {
@@ -20267,17 +20307,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@blueprintjs/colors": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/colors/-/colors-4.1.0.tgz",
-      "integrity": "sha512-aXgkEBg2oEz6lCE/sidvREUzQF7eJq2R8BvfOcQ1ICV4r/KVFszee6seA12ZtVaphfvuR4EE/raH6F1d0f4y7g=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/colors/-/colors-4.1.1.tgz",
+      "integrity": "sha512-uA/TDvIOG/TJ+mDJNerFRK5WnUJlInbRshzHI5SbJXlaPXXIj5BMxAXB67izH0gjvSNj5cXy/9UIgTO2WCB7XA=="
     },
     "@blueprintjs/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-/bQN8mukY6VdeB1Bv2j/GQmJILe+drTNT4cO958QwGvPaJWLLD2Z/XdfTj8ffoWtYMrDLvVKkXKHt99gOnlUJQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-4.2.1.tgz",
+      "integrity": "sha512-hd5kiPzyicfqYsapMiNRG2SNQGJK+pkJH914xODVBmF0SK4jnmZk1cCEjhNfp9ibjxHxOCZsxAU7Gy8NgAonyw==",
       "requires": {
-        "@blueprintjs/colors": "^4.1.0",
-        "@blueprintjs/icons": "^4.2.3",
+        "@blueprintjs/colors": "^4.1.1",
+        "@blueprintjs/icons": "^4.2.4",
         "@juggle/resize-observer": "^3.3.1",
         "@types/dom4": "^2.0.1",
         "classnames": "^2.2",
@@ -20290,13 +20330,38 @@
       }
     },
     "@blueprintjs/icons": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-4.2.3.tgz",
-      "integrity": "sha512-6xPneQo7bCkO96q9zOhXVh7/6QkIb8weHIwH5uyt5rmvq9/QTYcw0T2hOKiqqmDCvzv5OlZpY9QC+8deKVWWpQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-4.2.4.tgz",
+      "integrity": "sha512-dbRoAmh4SCQGCuIgMmxYHcAknW9MIhASYbvlzSPR6fV9poewuMemzTQMLiLT8Ztvigb7YwkBZjDSDF3yq6s5uw==",
       "requires": {
         "change-case": "^4.1.2",
         "classnames": "^2.2",
         "tslib": "~2.3.1"
+      }
+    },
+    "@blueprintjs/popover2": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/popover2/-/popover2-1.1.4.tgz",
+      "integrity": "sha512-waco9U5IDlZ+1zYTZK7eC/TLH8IFhKEAMUrt0hVQw4au6Chb+edyWOXhuvopmR/akR0wTTX8kgaptxJ+zmAxvg==",
+      "requires": {
+        "@blueprintjs/core": "^4.2.1",
+        "@juggle/resize-observer": "^3.3.1",
+        "@popperjs/core": "^2.5.4",
+        "classnames": "^2.2",
+        "dom4": "^2.1.5",
+        "react-popper": "^2.2.4",
+        "tslib": "~2.3.1"
+      },
+      "dependencies": {
+        "react-popper": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+          "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+          "requires": {
+            "react-fast-compare": "^3.0.1",
+            "warning": "^4.0.2"
+          }
+        }
       }
     },
     "@blueprintjs/select": {
@@ -21380,6 +21445,11 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@react-hook/debounce": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4456,7 +4456,7 @@
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -4477,7 +4477,7 @@
       "version": "17.0.44",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
       "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4540,7 +4540,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -21469,14 +21469,12 @@
     "@react-hook/event": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@react-hook/event/-/event-1.2.6.tgz",
-      "integrity": "sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q==",
-      "requires": {}
+      "integrity": "sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q=="
     },
     "@react-hook/latest": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
-      "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
-      "requires": {}
+      "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg=="
     },
     "@react-hook/throttle": {
       "version": "2.2.0",
@@ -22233,7 +22231,7 @@
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "devOptional": true
+      "dev": true
     },
     "@types/q": {
       "version": "1.5.5",
@@ -22254,7 +22252,7 @@
       "version": "17.0.44",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz",
       "integrity": "sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -22317,7 +22315,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "dev": true
     },
     "@types/serve-index": {
       "version": "1.9.1",
@@ -22698,14 +22696,12 @@
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "requires": {}
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -22791,8 +22787,7 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -23099,8 +23094,7 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "requires": {}
+      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -23778,8 +23772,7 @@
     "css-declaration-sorter": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
-      "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
-      "requires": {}
+      "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg=="
     },
     "css-has-pseudo": {
       "version": "3.0.4",
@@ -23862,8 +23855,7 @@
     "css-prefers-color-scheme": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "requires": {}
+      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA=="
     },
     "css-select": {
       "version": "2.1.0",
@@ -23967,8 +23959,7 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "requires": {}
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
     },
     "csso": {
       "version": "4.2.0",
@@ -25048,8 +25039,7 @@
     "eslint-plugin-react-hooks": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz",
-      "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
-      "requires": {}
+      "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ=="
     },
     "eslint-plugin-testing-library": {
       "version": "5.3.1",
@@ -26066,8 +26056,7 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "requires": {}
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
     },
     "idb": {
       "version": "6.1.5",
@@ -27751,8 +27740,7 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "requires": {}
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -29592,8 +29580,7 @@
     "postcss-browser-comments": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
-      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
-      "requires": {}
+      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg=="
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -29658,8 +29645,7 @@
     "postcss-custom-media": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
-      "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
-      "requires": {}
+      "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g=="
     },
     "postcss-custom-properties": {
       "version": "12.1.7",
@@ -29688,26 +29674,22 @@
     "postcss-discard-comments": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
-      "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
-      "requires": {}
+      "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ=="
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "requires": {}
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "requires": {}
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "requires": {}
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
     },
     "postcss-double-position-gradients": {
       "version": "3.1.1",
@@ -29729,8 +29711,7 @@
     "postcss-flexbugs-fixes": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-      "requires": {}
+      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -29751,14 +29732,12 @@
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "requires": {}
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
     },
     "postcss-gap-properties": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
-      "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
-      "requires": {}
+      "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ=="
     },
     "postcss-image-set-function": {
       "version": "4.0.6",
@@ -29771,8 +29750,7 @@
     "postcss-initial": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "requires": {}
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -29813,14 +29791,12 @@
     "postcss-logical": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "requires": {}
+      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g=="
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "requires": {}
+      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ=="
     },
     "postcss-merge-longhand": {
       "version": "5.1.4",
@@ -29881,8 +29857,7 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "requires": {}
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -29939,8 +29914,7 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "requires": {}
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -30025,14 +29999,12 @@
     "postcss-overflow-shorthand": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
-      "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-      "requires": {}
+      "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg=="
     },
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "requires": {}
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
     },
     "postcss-place": {
       "version": "7.0.4",
@@ -30120,8 +30092,7 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "requires": {}
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
     },
     "postcss-selector-not": {
       "version": "5.0.0",
@@ -31595,8 +31566,7 @@
     "style-loader": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "requires": {}
+      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ=="
     },
     "stylehacks": {
       "version": "5.1.0",
@@ -31844,8 +31814,7 @@
     "three-spritetext": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/three-spritetext/-/three-spritetext-1.6.5.tgz",
-      "integrity": "sha512-ttA1ce3tJz6OFojLGY3VjtqF9johetq50TztYcPFWqdEUrwPmej5XXcHahVyQGd88FHRDzJmW2rW3zSifUsdYA==",
-      "requires": {}
+      "integrity": "sha512-ttA1ce3tJz6OFojLGY3VjtqF9johetq50TztYcPFWqdEUrwPmej5XXcHahVyQGd88FHRDzJmW2rW3zSifUsdYA=="
     },
     "throat": {
       "version": "6.0.1",
@@ -32412,8 +32381,7 @@
         "ws": {
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "requires": {}
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
         }
       }
     },
@@ -32855,8 +32823,7 @@
     "ws": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "requires": {}
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "@blueprintjs/core": "^4.2.0",
+    "@blueprintjs/popover2": "^1.1.4",
     "@blueprintjs/select": "^4.1.3",
     "@craco/craco": "^7.0.0-alpha.3",
     "@react-hook/window-size": "^3.0.7",

--- a/src/components/OntologyExplorer/Controls.tsx
+++ b/src/components/OntologyExplorer/Controls.tsx
@@ -44,7 +44,6 @@ export default function OntrologyExplorerControlDrawer(props: OntrologyExplorerC
     omniXref,
     pinnedVertex,
     dagSearchText,
-    simulationRunning,
     menubarHeight,
     isSubset,
     handleDagSearchChange,
@@ -101,27 +100,12 @@ export default function OntrologyExplorerControlDrawer(props: OntrologyExplorerC
       >
         cellxgene-ontology
       </p>
-      <div style={{ marginRight: 20 }}>
-        <InputGroup
-          type="text"
-          leftIcon="geosearch"
-          placeholder="cell type search"
-          disabled={simulationRunning}
-          style={{
-            fontSize: 14,
-            marginRight: 20,
-          }}
-          onChange={(e) => {
-            handleDagSearchChange(e);
-          }}
-          value={simulationRunning ? "computing layout..." : dagSearchText}
-        />
-      </div>
 
       <Button onClick={deselectPinnedNode} style={{ marginRight: 20 }} disabled={!pinnedVertex}>
         Deselect
       </Button>
-      {pinnedVertex && (
+
+      {/* {pinnedVertex && (
         <Button icon="pie-chart" onClick={subsetToNode} style={{ marginRight: 20 }}>
           subset to {pinnedVertex.id}
         </Button>
@@ -130,7 +114,7 @@ export default function OntrologyExplorerControlDrawer(props: OntrologyExplorerC
         <Button icon="full-circle" onClick={resetSubset} style={{ marginRight: 20 }}>
           reset to whole
         </Button>
-      )}
+      )} */}
 
       <Drawer
         isOpen={settingsIsOpen}
@@ -224,9 +208,9 @@ export default function OntrologyExplorerControlDrawer(props: OntrologyExplorerC
         </div>
         <div className={Classes.DRAWER_FOOTER}>A lovely footer</div>
       </Drawer>
-      <Button style={{ marginRight: 20 }} onClick={handleXrefSearchOpen}>
+      {/* <Button style={{ marginRight: 20 }} onClick={handleXrefSearchOpen}>
         Search {omniXref.name} (c)
-      </Button>
+      </Button> */}
       <XrefOmnibar
         isOpen={xrefSearchIsOpen}
         onClose={handleXrefSearchClose}

--- a/src/components/OntologyExplorer/index.tsx
+++ b/src/components/OntologyExplorer/index.tsx
@@ -340,23 +340,23 @@ export default function OntologyExplorer({ graph, omniXref }: OntologyExplorerPr
             position: "absolute",
             right: 0,
             top: 0,
-            width: cardWidth,
+            width: cardWidth + 50,
             padding: cardPadding,
           }}
         >
           <SearchSidebar
             terms={[
               {
-                highlight: true,
-                action: "none", //include, exclude, none, (string)
-                match: "neuron ",
-                compartment: "",
-              },
-              {
                 highlight: false, // (boolean)
                 action: "include", //include, exclude, none, (string)
-                match: "",
-                compartment: "eye",
+                searchString: "eye",
+                searchMode: "compartment",
+              },
+              {
+                highlight: true,
+                action: "none", //include, exclude, none, (string)
+                searchString: "neuron ",
+                searchMode: "terms that match in CL",
               },
             ]}
           />

--- a/src/components/OntologyExplorer/index.tsx
+++ b/src/components/OntologyExplorer/index.tsx
@@ -61,6 +61,20 @@ export default function OntologyExplorer({ graph, omniXref }: OntologyExplorerPr
   const [hoverNode, setHoverNode] = useState<OntologyVertexDatum>();
   const [simulationRunning, setSimulationRunning] = useState<boolean>(false);
   const [dagState, setDagState] = useState<DagState | null>(null);
+  const [searchTerms, setSearchTerms] = useState([
+    {
+      highlight: false, // (boolean)
+      action: "include", //include, exclude, none, (string)
+      searchString: "eye",
+      searchMode: "compartment",
+    },
+    {
+      highlight: true,
+      action: "none", //include, exclude, none, (string)
+      searchString: "neuron ",
+      searchMode: "terms that match in CL",
+    },
+  ]);
   const [forceCanvasHighlightProps, setForceCanvasHighlightProps] =
     useState<DrawForceDagHighlightProps>(defaultForceHightlightProps);
   const [redrawCanvas, setRedrawCanvas] = useState<((p?: DrawForceDagHighlightProps) => void) | null>(null);
@@ -344,22 +358,7 @@ export default function OntologyExplorer({ graph, omniXref }: OntologyExplorerPr
             padding: cardPadding,
           }}
         >
-          <SearchSidebar
-            terms={[
-              {
-                highlight: false, // (boolean)
-                action: "include", //include, exclude, none, (string)
-                searchString: "eye",
-                searchMode: "compartment",
-              },
-              {
-                highlight: true,
-                action: "none", //include, exclude, none, (string)
-                searchString: "neuron ",
-                searchMode: "terms that match in CL",
-              },
-            ]}
-          />
+          <SearchSidebar terms={searchTerms} setTerms={setSearchTerms} />
         </div>
         {/**
          * Render sugiyama

--- a/src/components/OntologyExplorer/index.tsx
+++ b/src/components/OntologyExplorer/index.tsx
@@ -7,6 +7,7 @@ import { drawForceDag, DrawForceDagHighlightProps, NodeHighlight } from "./drawF
 import Vertex from "../Vertex";
 import Sugiyama from "./Sugiyama";
 import Controls from "./Controls";
+import SearchSidebar from "./searchSidebar";
 import { OntologyId, OntologyTerm, OntologyPrefix, DatasetGraph } from "../../d";
 import {
   ForceCanvasProps,
@@ -42,7 +43,7 @@ const defaultForceHightlightProps: DrawForceDagHighlightProps = {
 
 const defaultState: OntologyExplorerState = {
   dagCreateProps: {
-    minimumOutdegree: 3,
+    minimumOutdegree: 0,
     maximumOutdegree: 12345,
     outdegreeCutoffXYZ: 0,
     doCreateSugiyamaDatastructure: true,
@@ -66,6 +67,7 @@ export default function OntologyExplorer({ graph, omniXref }: OntologyExplorerPr
 
   const windowHeight = useWindowHeight();
   const menubarHeight = 50;
+  const cardPadding = 10;
 
   const { dagCreateProps, cardWidth, sugiyamaRenderThreshold } = state;
 
@@ -308,7 +310,7 @@ export default function OntologyExplorer({ graph, omniXref }: OntologyExplorerPr
             margin: 0,
           }}
         >
-          <div id="innerDivToPreventPaddingSizeIncrease" style={{ padding: 10 }}>
+          <div id="innerDivToPreventPaddingSizeIncrease" style={{ padding: cardPadding }}>
             {/**
              * Render cards
              */}
@@ -336,6 +338,33 @@ export default function OntologyExplorer({ graph, omniXref }: OntologyExplorerPr
           height={forceCanvasHeight * window.devicePixelRatio}
           ref={dagCanvasRef}
         />
+        <div
+          id="rightSideBarContainer"
+          style={{
+            position: "absolute",
+            right: 0,
+            top: 0,
+            width: cardWidth,
+            padding: cardPadding,
+          }}
+        >
+          <SearchSidebar
+            terms={[
+              {
+                highlight: true,
+                action: "none", //include, exclude, none, (string)
+                match: "neuron ",
+                compartment: "",
+              },
+              {
+                highlight: false, // (boolean)
+                action: "include", //include, exclude, none, (string)
+                match: "",
+                compartment: "eye",
+              },
+            ]}
+          />
+        </div>
         {/**
          * Render sugiyama
          */}

--- a/src/components/OntologyExplorer/searchSidebar.tsx
+++ b/src/components/OntologyExplorer/searchSidebar.tsx
@@ -22,10 +22,25 @@ const SearchSidebar = (props: SearchSidebarProps) => {
   const marginUnit = 15;
   return (
     <div>
-      <h2 style={{ marginBottom: marginUnit * 2 }}>Search & filter</h2>
+      <div style={{ marginBottom: marginUnit * 2 }}>
+        <h2>Search & filter</h2>
+        <p style={{ fontStyle: "italic" }}>Searches are execulted in the order they appear here.</p>
+      </div>
       {terms.map((term) => {
         return <SearchTerm term={term} marginUnit={marginUnit} />;
       })}
+      <input type="text" />
+      <RadioGroup
+        onChange={(d) => {
+          console.log("search mode");
+        }}
+        selectedValue={"none"}
+      >
+        <Radio label={`compartment (e.g., eye, lung, UBERON:0002048)`} value="compartment" />
+        <Radio label={`terms (e.g., b cell, neuron, CL:0000057)`} value="terms" />
+        <Radio label={`terms and their children (e.g., b cell, neuron)`} value="terms and children" />
+      </RadioGroup>
+
       <Button
         style={{ marginTop: marginUnit }}
         onClick={() => {
@@ -63,7 +78,6 @@ const SearchTerm = (props: SearchTermProps) => {
               >
                 <Radio label="none" value="none" />
                 <Radio label={`keep nodes matching: ${term.match} ${term.compartment}`} value="keep graph to only" />
-
                 <Radio label={`remove nodes matching: ${term.match} ${term.compartment}`} value="remove just this" />
               </RadioGroup>
             }

--- a/src/components/OntologyExplorer/searchSidebar.tsx
+++ b/src/components/OntologyExplorer/searchSidebar.tsx
@@ -1,0 +1,85 @@
+import { Button, RadioGroup, Radio, Icon, ButtonGroup } from "@blueprintjs/core";
+import { Classes, Popover2 } from "@blueprintjs/popover2";
+
+interface Term {
+  highlight: boolean;
+  action: string; //include, exclude, none, so could be 'one of'
+  match: string;
+  compartment: string;
+}
+
+interface SearchSidebarProps {
+  terms: Term[];
+}
+
+interface SearchTermProps {
+  term: Term;
+  marginUnit: number;
+}
+
+const SearchSidebar = (props: SearchSidebarProps) => {
+  const { terms } = props;
+  const marginUnit = 15;
+  return (
+    <div>
+      <h2 style={{ marginBottom: marginUnit * 2 }}>Search & filter</h2>
+      {terms.map((term) => {
+        return <SearchTerm term={term} marginUnit={marginUnit} />;
+      })}
+      <Button
+        style={{ marginTop: marginUnit }}
+        onClick={() => {
+          console.log("for now, perhaps this just triggers xrefSearchIsOpen true");
+        }}
+        icon={<Icon icon="plus" iconSize={16} />}
+      >
+        Add search term
+      </Button>
+    </div>
+  );
+};
+
+const SearchTerm = (props: SearchTermProps) => {
+  const { term, marginUnit } = props;
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 15 }}>
+      <div style={{ width: 290, display: "flex", alignItems: "center", justifyContent: "flex-start" }}>
+        <Button
+          onClick={() => {
+            console.log("color by ", term.match, term.compartment);
+          }}
+          icon={<Icon icon="tint" iconSize={16} />}
+        />
+        <span style={{ marginLeft: marginUnit, marginRight: marginUnit }}>
+          {term.match}
+          {term.compartment}
+        </span>
+        <Popover2
+          popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
+          content={
+            <RadioGroup
+              onChange={(d) => {
+                console.log("graph action radio button selection");
+              }}
+              selectedValue={"none"}
+            >
+              <Radio label="none" value="none" />
+              <Radio label={`keep nodes matching: ${term.match} ${term.compartment}`} value="keep graph to only" />
+
+              <Radio label={`remove nodes matching: ${term.match} ${term.compartment}`} value="remove just this" />
+            </RadioGroup>
+          }
+          placement={"bottom-end"}
+        >
+          <Button
+            rightIcon={<Icon icon="caret-down" iconSize={16} />}
+            icon={<Icon icon={"filter" /* set depending on selection */} iconSize={16} />}
+          />
+        </Popover2>
+      </div>
+      <Button minimal icon={<Icon icon="delete" iconSize={16} />} />
+    </div>
+  );
+};
+
+export default SearchSidebar;

--- a/src/components/OntologyExplorer/searchSidebar.tsx
+++ b/src/components/OntologyExplorer/searchSidebar.tsx
@@ -1,11 +1,11 @@
-import { Button, RadioGroup, Radio, Icon, ButtonGroup } from "@blueprintjs/core";
+import { Button, RadioGroup, Radio, Icon, ButtonGroup, InputGroup, ControlGroup, HTMLSelect } from "@blueprintjs/core";
 import { Classes, Popover2 } from "@blueprintjs/popover2";
 
 interface Term {
   highlight: boolean;
   action: string; //include, exclude, none, so could be 'one of'
-  match: string;
-  compartment: string;
+  searchString: string;
+  searchMode: string;
 }
 
 interface SearchSidebarProps {
@@ -24,32 +24,28 @@ const SearchSidebar = (props: SearchSidebarProps) => {
     <div>
       <div style={{ marginBottom: marginUnit * 2 }}>
         <h2>Search & filter</h2>
-        <p style={{ fontStyle: "italic" }}>Searches are execulted in the order they appear here.</p>
+        <p style={{ fontStyle: "italic" }}>
+          Search & add terms: a search might be a compartment (e.g., eye, lung, UBERON:0002048) or cell type (e.g., T
+          cell, neuron, CL:0000057).
+        </p>
+        <p style={{ fontStyle: "italic" }}>
+          Use terms to modify the graph: they are executed in the order they appear.
+        </p>
       </div>
-      {terms.map((term) => {
-        return <SearchTerm term={term} marginUnit={marginUnit} />;
+      <ControlGroup fill style={{ marginBottom: marginUnit * 2 }}>
+        <HTMLSelect options={[`🫁 compartment`, `cell type`]} />
+        <InputGroup placeholder="Search..." />
+        <Button
+          icon="plus"
+          onClick={(e) => {
+            console.log("add term", e.target);
+          }}
+        />
+      </ControlGroup>
+      {terms.map((term, i) => {
+        return <SearchTerm key={i} term={term} marginUnit={marginUnit} />;
       })}
-      <input type="text" />
-      <RadioGroup
-        onChange={(d) => {
-          console.log("search mode");
-        }}
-        selectedValue={"none"}
-      >
-        <Radio label={`compartment (e.g., eye, lung, UBERON:0002048)`} value="compartment" />
-        <Radio label={`terms (e.g., b cell, neuron, CL:0000057)`} value="terms" />
-        <Radio label={`terms and their children (e.g., b cell, neuron)`} value="terms and children" />
-      </RadioGroup>
-
-      <Button
-        style={{ marginTop: marginUnit }}
-        onClick={() => {
-          console.log("for now, perhaps this just triggers xrefSearchIsOpen true");
-        }}
-        icon={<Icon icon="plus" iconSize={16} />}
-      >
-        Add search term
-      </Button>
+      <div style={{ marginTop: marginUnit * 3 }}></div>
     </div>
   );
 };
@@ -62,7 +58,7 @@ const SearchTerm = (props: SearchTermProps) => {
         <ButtonGroup>
           <Button
             onClick={() => {
-              console.log("color by ", term.match, term.compartment);
+              console.log("color by ", term.searchString);
             }}
             icon={<Icon icon="tint" iconSize={16} />}
           />
@@ -71,14 +67,14 @@ const SearchTerm = (props: SearchTermProps) => {
             popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
             content={
               <RadioGroup
-                onChange={(d) => {
-                  console.log("graph action radio button selection");
+                onChange={(e) => {
+                  console.log("change graph: ", e.currentTarget.value, term.searchString);
                 }}
                 selectedValue={"none"}
               >
                 <Radio label="none" value="none" />
-                <Radio label={`keep nodes matching: ${term.match} ${term.compartment}`} value="keep graph to only" />
-                <Radio label={`remove nodes matching: ${term.match} ${term.compartment}`} value="remove just this" />
+                <Radio label={`keep nodes matching: ${term.searchString}`} value="keep only term" />
+                <Radio label={`remove nodes matching: ${term.searchString}`} value="remove term" />
               </RadioGroup>
             }
             placement={"bottom-end"}
@@ -90,12 +86,20 @@ const SearchTerm = (props: SearchTermProps) => {
           </Popover2>
         </ButtonGroup>
 
-        <span style={{ marginLeft: marginUnit, marginRight: marginUnit }}>
-          {term.match}
-          {term.compartment}
-        </span>
+        <span style={{ marginLeft: marginUnit, marginRight: marginUnit }}>{term.searchString}</span>
       </div>
-      <Button minimal icon={<Icon icon="delete" iconSize={16} />} />
+      <Button
+        minimal
+        icon={
+          <Icon
+            icon="delete"
+            iconSize={16}
+            onClick={() => {
+              console.log("remove term ", term.searchString);
+            }}
+          />
+        }
+      />
     </div>
   );
 };

--- a/src/components/OntologyExplorer/searchSidebar.tsx
+++ b/src/components/OntologyExplorer/searchSidebar.tsx
@@ -1,5 +1,6 @@
 import { Button, RadioGroup, Radio, Icon, ButtonGroup, InputGroup, ControlGroup, HTMLSelect } from "@blueprintjs/core";
 import { Classes, Popover2 } from "@blueprintjs/popover2";
+import { useState } from "react";
 
 interface Term {
   highlight: boolean;
@@ -10,6 +11,7 @@ interface Term {
 
 interface SearchSidebarProps {
   terms: Term[];
+  setTerms: any;
 }
 
 interface SearchTermProps {
@@ -18,8 +20,11 @@ interface SearchTermProps {
 }
 
 const SearchSidebar = (props: SearchSidebarProps) => {
-  const { terms } = props;
+  const { terms, setTerms } = props;
   const marginUnit = 15;
+  const [searchString, setSearchString] = useState("");
+  const [searchMode, setSearchMode] = useState("🫁 compartment");
+
   return (
     <div>
       <div style={{ marginBottom: marginUnit * 2 }}>
@@ -33,12 +38,25 @@ const SearchSidebar = (props: SearchSidebarProps) => {
         </p>
       </div>
       <ControlGroup fill style={{ marginBottom: marginUnit * 2 }}>
-        <HTMLSelect options={[`🫁 compartment`, `cell type`]} />
-        <InputGroup placeholder="Search..." />
+        <HTMLSelect
+          value={searchMode}
+          options={[`🫁 compartment`, `cell type`]}
+          onChange={(e) => {
+            setSearchMode(e.target.value);
+          }}
+        />
+        <InputGroup
+          placeholder="Search..."
+          value={searchString}
+          onChange={(e) => {
+            setSearchString(e.target.value);
+          }}
+        />
         <Button
           icon="plus"
-          onClick={(e) => {
-            console.log("add term", e.target);
+          onClick={() => {
+            setTerms([...terms, { highlight: false, action: "none", searchString, searchMode }]);
+            setSearchString("");
           }}
         />
       </ControlGroup>

--- a/src/components/OntologyExplorer/searchSidebar.tsx
+++ b/src/components/OntologyExplorer/searchSidebar.tsx
@@ -44,38 +44,42 @@ const SearchTerm = (props: SearchTermProps) => {
   return (
     <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 15 }}>
       <div style={{ width: 290, display: "flex", alignItems: "center", justifyContent: "flex-start" }}>
-        <Button
-          onClick={() => {
-            console.log("color by ", term.match, term.compartment);
-          }}
-          icon={<Icon icon="tint" iconSize={16} />}
-        />
+        <ButtonGroup>
+          <Button
+            onClick={() => {
+              console.log("color by ", term.match, term.compartment);
+            }}
+            icon={<Icon icon="tint" iconSize={16} />}
+          />
+
+          <Popover2
+            popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
+            content={
+              <RadioGroup
+                onChange={(d) => {
+                  console.log("graph action radio button selection");
+                }}
+                selectedValue={"none"}
+              >
+                <Radio label="none" value="none" />
+                <Radio label={`keep nodes matching: ${term.match} ${term.compartment}`} value="keep graph to only" />
+
+                <Radio label={`remove nodes matching: ${term.match} ${term.compartment}`} value="remove just this" />
+              </RadioGroup>
+            }
+            placement={"bottom-end"}
+          >
+            <Button
+              rightIcon={<Icon icon="caret-down" iconSize={16} />}
+              icon={<Icon icon={"filter" /* set depending on selection */} iconSize={16} />}
+            />
+          </Popover2>
+        </ButtonGroup>
+
         <span style={{ marginLeft: marginUnit, marginRight: marginUnit }}>
           {term.match}
           {term.compartment}
         </span>
-        <Popover2
-          popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
-          content={
-            <RadioGroup
-              onChange={(d) => {
-                console.log("graph action radio button selection");
-              }}
-              selectedValue={"none"}
-            >
-              <Radio label="none" value="none" />
-              <Radio label={`keep nodes matching: ${term.match} ${term.compartment}`} value="keep graph to only" />
-
-              <Radio label={`remove nodes matching: ${term.match} ${term.compartment}`} value="remove just this" />
-            </RadioGroup>
-          }
-          placement={"bottom-end"}
-        >
-          <Button
-            rightIcon={<Icon icon="caret-down" iconSize={16} />}
-            icon={<Icon icon={"filter" /* set depending on selection */} iconSize={16} />}
-          />
-        </Popover2>
       </div>
       <Button minimal icon={<Icon icon="delete" iconSize={16} />} />
     </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import "@blueprintjs/core/lib/css/blueprint.css";
-// import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
+import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 import "@blueprintjs/select/lib/css/blueprint-select.css";
 import { HotkeysProvider } from "@blueprintjs/core";
 


### PR DESCRIPTION
Introduces UI (but not wiring) for search functionality in a right sidebar, and implements a multistep process. First, scientists can choose via dropdown whether to search cell types or compartments, then add search terms to a set of filters which can then be activated to modify the graph (removing all epithelial, subsetting to eye, locating all cells type neurons, etc).

The following schema for a 'term' is introduced:

```
{ 
  highlight: 1, (boolean)
  action: include, exclude, none, (string)
  searchString: “”,
  searchMode: “compartment” | “terms that match in CL” | “terms that match in CL plus children”
}
```

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/1770265/165892516-afb894d4-37ff-4202-b573-28ab9a1f4661.png">
