### PR TITLE
Add terms from selected vertex 

### DIFF
--- a/src/components/OntologyExplorer/index.tsx
+++ b/src/components/OntologyExplorer/index.tsx
@@ -270,10 +270,24 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
              * Render cards
              */}
             {!pinnedVertex && hoverVertex && (
-              <Vertex graph={graph} vertex={hoverVertex} query={query} makeTo={(id: OntologyId) => makeLsbTo(id)} />
+              <Vertex
+                searchTerms={searchTerms}
+                setSearchTerms={handleSetSearchTerms}
+                graph={graph}
+                vertex={hoverVertex}
+                query={query}
+                makeTo={(id: OntologyId) => makeLsbTo(id)}
+              />
             )}
             {pinnedVertex && (
-              <Vertex graph={graph} vertex={pinnedVertex} query={query} makeTo={(id: OntologyId) => makeLsbTo(id)} />
+              <Vertex
+                searchTerms={searchTerms}
+                setSearchTerms={handleSetSearchTerms}
+                graph={graph}
+                vertex={pinnedVertex}
+                query={query}
+                makeTo={(id: OntologyId) => makeLsbTo(id)}
+              />
             )}
           </div>
         </div>

--- a/src/components/OntologyExplorer/searchSidebar.tsx
+++ b/src/components/OntologyExplorer/searchSidebar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button, RadioGroup, Radio, Icon, ButtonGroup, InputGroup, ControlGroup, HTMLSelect } from "@blueprintjs/core";
 import { Classes, Popover2 } from "@blueprintjs/popover2";
 import memoizeOne from "memoize-one";
+import { spawn } from "child_process";
 
 export type FilterMode = "none" | "keep" | "remove";
 export type SearchMode = "compartment" | "celltype";
@@ -66,7 +67,15 @@ const SearchSidebar = (props: SearchSidebarProps) => {
           Use terms to modify the graph: they are executed in the order they appear.
         </p>
       </div>
-      <ControlGroup fill style={{ marginBottom: marginUnit * 2 }}>
+
+      <form
+        style={{ display: "flex", justifyContent: "space-between", marginBottom: marginUnit * 2 }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          setSearchTerms([...searchTerms, { highlight: true, searchString, searchMode, filterMode: "none" }]);
+          setSearchString("");
+        }}
+      >
         <HTMLSelect
           value={searchMode}
           options={SearchModes}
@@ -75,6 +84,7 @@ const SearchSidebar = (props: SearchSidebarProps) => {
           }}
         />
         <InputGroup
+          style={{ width: 200 }}
           placeholder="Search..."
           value={searchString}
           onChange={(e) => {
@@ -83,13 +93,15 @@ const SearchSidebar = (props: SearchSidebarProps) => {
         />
         <Button
           icon="plus"
+          type={"submit"}
           disabled={!searchString}
           onClick={() => {
             setSearchTerms([...searchTerms, { highlight: true, searchString, searchMode, filterMode: "none" }]);
             setSearchString("");
           }}
         />
-      </ControlGroup>
+      </form>
+
       {searchTerms.map((term, i) => {
         return (
           <SearchTermView
@@ -109,6 +121,15 @@ const SearchSidebar = (props: SearchSidebarProps) => {
 
 const SearchTermView = (props: SearchTermProps) => {
   const { id, term, marginUnit, onDelete, onChange } = props;
+
+  let filterIcon: "filter" | "filter-keep" | "filter-remove" = "filter";
+
+  if (term.filterMode === "keep") {
+    filterIcon = "filter-keep";
+  } else if (term.filterMode === "remove") {
+    filterIcon = "filter-remove";
+  }
+
   return (
     <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 15 }}>
       <div style={{ width: 290, display: "flex", alignItems: "center", justifyContent: "flex-start" }}>
@@ -136,11 +157,16 @@ const SearchTermView = (props: SearchTermProps) => {
           >
             <Button
               rightIcon={<Icon icon="caret-down" iconSize={16} />}
-              icon={<Icon icon={"filter" /* set depending on selection */} iconSize={16} />}
+              icon={<Icon icon={filterIcon} iconSize={16} />}
             />
           </Popover2>
         </ButtonGroup>
-        <span style={{ marginLeft: marginUnit, marginRight: marginUnit }}>{term.searchString}</span>
+        <div style={{ display: "flex", flexDirection: "column", position: "relative", top: -1 }}>
+          <span style={{ marginLeft: marginUnit, marginRight: marginUnit }}>{term.searchString}</span>
+          <span style={{ marginLeft: marginUnit, marginRight: marginUnit, fontSize: 10 }}>
+            {term.searchMode === "compartment" ? "🫁 compartment" : "cell type"}
+          </span>
+        </div>
       </div>
       <Button minimal icon={<Icon icon="delete" iconSize={16} onClick={() => onDelete(id)} />} />
     </div>
@@ -164,8 +190,9 @@ export function urlSearchParamToSearchTerm(qstr: string): SearchTerm {
 }
 
 export const urlSearchParamsToSearchTerms = memoizeOne(
-  (paramStrings: string[]): SearchTerm[] => paramStrings.map(urlSearchParamToSearchTerm), 
-  (first: [string[]], second: [string[]]) => first[0].join(';') === second[0].join(';'))
+  (paramStrings: string[]): SearchTerm[] => paramStrings.map(urlSearchParamToSearchTerm),
+  (first: [string[]], second: [string[]]) => first[0].join(";") === second[0].join(";")
+);
 
 export function searchTermsToSearchQueries(terms: SearchTerm[]): string[] {
   return terms.map(searchTermToUrlSearchParam);

--- a/src/components/OntologyExplorer/searchSidebar.tsx
+++ b/src/components/OntologyExplorer/searchSidebar.tsx
@@ -58,7 +58,9 @@ const SearchSidebar = (props: SearchSidebarProps) => {
   return (
     <div>
       <div style={{ marginBottom: marginUnit * 2 }}>
-        <h2>Search &amp; filter</h2>
+        <h2>
+          <Icon icon={"search"} style={{ position: "relative", top: -4, marginRight: 5 }} /> Search &amp; filter
+        </h2>
         <p style={{ fontStyle: "italic" }}>
           Search &amp; add terms: a search might be a compartment (e.g., eye, lung, UBERON:0002048) or cell type (e.g.,
           T cell, neuron, CL:0000057).

--- a/src/components/Vertex.tsx
+++ b/src/components/Vertex.tsx
@@ -12,8 +12,8 @@ export interface VertexProps {
   vertex: OntologyTerm;
   query?: string;
   makeTo: (to: OntologyId) => string;
-  searchTerms: SearchTerm[];
-  setSearchTerms: (searches: SearchTerm[]) => void;
+  searchTerms?: SearchTerm[];
+  setSearchTerms?: (searches: SearchTerm[]) => void;
 }
 
 export default function Vertex({ graph, vertex, query, makeTo, searchTerms, setSearchTerms }: VertexProps) {
@@ -38,15 +38,55 @@ export default function Vertex({ graph, vertex, query, makeTo, searchTerms, setS
 
   return (
     <div>
-      <h1>{vertex && vertex.label}</h1>
+      <h1>
+        {vertex && vertex.label}{" "}
+        {searchTerms && setSearchTerms && (
+          <Button
+            minimal
+            icon={<Icon icon={"search"} iconSize={16} />}
+            style={{ position: "relative", top: -1.5, left: -2 }}
+            onClick={() => {
+              setSearchTerms([
+                ...searchTerms,
+                { highlight: true, searchString: vertex.label, searchMode: "celltype", filterMode: "none" },
+              ]);
+            }}
+          />
+        )}
+      </h1>
       <h5>Count: {vertex && vertex.n_cells ? vertex.n_cells : "0"}</h5>
-
       <p>{!olsTerm && "Loading..."}</p>
       <p>{olsTerm && definition}</p>
-      <pre>{vertexID}</pre>
+      <pre>
+        {vertexID}{" "}
+        {searchTerms && setSearchTerms && (
+          <Button
+            small
+            minimal
+            icon={<Icon icon={"search"} iconSize={10} />}
+            style={{ position: "relative", top: -1.5, left: -2 }}
+            onClick={() => {
+              setSearchTerms([
+                ...searchTerms,
+                { highlight: true, searchString: vertexID, searchMode: "celltype", filterMode: "none" },
+              ]);
+            }}
+          />
+        )}
+      </pre>
+
+      {vertex.synonyms.length > 1 && (
+        <p style={{ fontStyle: "italic", color: "grey", fontSize: 10 }}>
+          Synonyms:{" "}
+          <span>
+            {vertex.synonyms.map((s) => {
+              return s;
+            })}
+          </span>
+        </p>
+      )}
 
       <h3> Parents </h3>
-
       <ul>
         {vertex &&
           vertex.parents.map((ancestor: string) => {
@@ -64,7 +104,6 @@ export default function Vertex({ graph, vertex, query, makeTo, searchTerms, setS
             );
           })}
       </ul>
-
       <h3> Children </h3>
       <ul>
         {vertex &&
@@ -83,8 +122,7 @@ export default function Vertex({ graph, vertex, query, makeTo, searchTerms, setS
             );
           })}
       </ul>
-
-      <h3> Part-of (compartment)</h3>
+      <h3>🫁 Part-of (compartment)</h3>
       <ul>
         {vertex &&
           allUniqueAncestors(graph, ontoID, vertex, "part_of").map((id: string, i: number) => {
@@ -92,23 +130,24 @@ export default function Vertex({ graph, vertex, query, makeTo, searchTerms, setS
             return (
               <li key={id}>
                 <Link to={makeTo(id)}>{term!.label}</Link>
-                <Button
-                  small
-                  minimal
-                  icon={<Icon icon={"search"} iconSize={10} />}
-                  style={{ marginLeft: 4 }}
-                  onClick={() => {
-                    setSearchTerms([
-                      ...searchTerms,
-                      { highlight: true, searchString: term!.label, searchMode: "compartment", filterMode: "none" },
-                    ]);
-                  }}
-                />
+                {searchTerms && setSearchTerms && (
+                  <Button
+                    small
+                    minimal
+                    icon={<Icon icon={"search"} iconSize={10} />}
+                    style={{ marginLeft: 4 }}
+                    onClick={() => {
+                      setSearchTerms([
+                        ...searchTerms,
+                        { highlight: true, searchString: term!.label, searchMode: "compartment", filterMode: "none" },
+                      ]);
+                    }}
+                  />
+                )}
               </li>
             );
           })}
       </ul>
-
       <h3> Derived-from</h3>
       <ul>
         {vertex &&
@@ -121,7 +160,6 @@ export default function Vertex({ graph, vertex, query, makeTo, searchTerms, setS
             );
           })}
       </ul>
-
       <h3> Develops-from</h3>
       <ul>
         {vertex &&

--- a/src/components/Vertex.tsx
+++ b/src/components/Vertex.tsx
@@ -4,15 +4,19 @@ import { Link } from "react-router-dom";
 import { olsLookupTermByOboId } from "../util/fetchEBITerm";
 import { DatasetGraph, EBIOlsTerm, OntologyTerm, OntologyId } from "../d";
 import { ontologyLookupId, ontologyQuery, LinkNames } from "../util/ontologyDag";
+import { SearchTerm } from "./OntologyExplorer/searchSidebar";
+import { Button, Icon } from "@blueprintjs/core";
 
 export interface VertexProps {
   graph: DatasetGraph;
   vertex: OntologyTerm;
   query?: string;
   makeTo: (to: OntologyId) => string;
+  searchTerms: SearchTerm[];
+  setSearchTerms: (searches: SearchTerm[]) => void;
 }
 
-export default function Vertex({ graph, vertex, query, makeTo }: VertexProps) {
+export default function Vertex({ graph, vertex, query, makeTo, searchTerms, setSearchTerms }: VertexProps) {
   const vertexID = vertex.id;
   const ontoID = vertexID?.split(":", 1)[0];
   const ontology = graph.ontologies[ontoID];
@@ -88,6 +92,18 @@ export default function Vertex({ graph, vertex, query, makeTo }: VertexProps) {
             return (
               <li key={id}>
                 <Link to={makeTo(id)}>{term!.label}</Link>
+                <Button
+                  small
+                  minimal
+                  icon={<Icon icon={"search"} iconSize={10} />}
+                  style={{ marginLeft: 4 }}
+                  onClick={() => {
+                    setSearchTerms([
+                      ...searchTerms,
+                      { highlight: true, searchString: term!.label, searchMode: "compartment", filterMode: "none" },
+                    ]);
+                  }}
+                />
               </li>
             );
           })}
@@ -100,7 +116,7 @@ export default function Vertex({ graph, vertex, query, makeTo }: VertexProps) {
             const term = ontologyLookupId(graph.ontologies, id)?.term;
             return (
               <li key={id}>
-                <Link to={makeTo(id)}>{term!.label}</Link>
+                <Link to={makeTo(id)}>{term!.label}</Link>{" "}
               </li>
             );
           })}

--- a/src/routes/VertexView.tsx
+++ b/src/routes/VertexView.tsx
@@ -14,5 +14,5 @@ export default function VertexView({ graph }: VertexViewProps) {
   const vertex = vertexID ? ontology?.get(vertexID) : undefined;
   if (!vertex) return null;
 
-  return null /* <Vertex graph={graph} vertex={vertex} makeTo={(id: OntologyId) => `../${id}`} /> */;
+  return <Vertex graph={graph} vertex={vertex} makeTo={(id: OntologyId) => `../${id}`} />;
 }

--- a/src/routes/VertexView.tsx
+++ b/src/routes/VertexView.tsx
@@ -14,5 +14,5 @@ export default function VertexView({ graph }: VertexViewProps) {
   const vertex = vertexID ? ontology?.get(vertexID) : undefined;
   if (!vertex) return null;
 
-  return <Vertex graph={graph} vertex={vertex} makeTo={(id: OntologyId) => `../${id}`} />;
+  return null /* <Vertex graph={graph} vertex={vertex} makeTo={(id: OntologyId) => `../${id}`} /> */;
 }


### PR DESCRIPTION
Users can add compartment terms from the left sidebar (vertex), and terms display current filter state and whether they are cell type or compartment

<img width="574" alt="image" src="https://user-images.githubusercontent.com/1770265/167251999-7fa74c80-69b4-4eec-baff-6b596a264b0e.png">
