### PR TITLE
Add hotkeys for esc & a

### DIFF
--- a/src/components/OntologyExplorer/Controls.tsx
+++ b/src/components/OntologyExplorer/Controls.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
-import { Button, Classes, Drawer, RadioGroup, Radio, Checkbox } from "@blueprintjs/core";
+import { Button, Classes, Drawer, RadioGroup, Radio, Checkbox, HotkeysTarget2, Icon, Tag } from "@blueprintjs/core";
+
 import { useParams } from "react-router-dom";
 
 import { OntologyTerm } from "../../d";
 import { Link } from "react-router-dom";
+import { ICON } from "@blueprintjs/core/lib/esm/common/classes";
 
 interface OntrologyExplorerControlDrawerProps {
   pinnedVertex: OntologyTerm | undefined;
@@ -68,9 +70,39 @@ export default function OntrologyExplorerControlDrawer(props: OntrologyExplorerC
       </p>
       {params.ontoID === "CL" && <Link to={"/a/ontology/UBERON"}> Switch to UBERON</Link>}
       {params.ontoID === "UBERON" && <Link to={"/a/ontology/CL"}> Switch to CL</Link>}
-      <Button onClick={deselectPinnedNode} style={{ marginRight: 20, marginLeft: 20 }} disabled={!pinnedVertex}>
-        Deselect
-      </Button>
+
+      <HotkeysTarget2
+        hotkeys={[
+          {
+            combo: "ESC",
+            global: true,
+            label: "Deselect pinned node",
+            onKeyDown: () => {
+              deselectPinnedNode();
+            },
+          },
+          {
+            combo: "A",
+            global: true,
+            label: "Highlight node ancestors",
+            onKeyDown: () => {
+              handleHighlightAncestorChange();
+            },
+          },
+        ]}
+      >
+        {({ handleKeyDown, handleKeyUp }) => (
+          <Button
+            tabIndex={0}
+            onClick={deselectPinnedNode}
+            style={{ marginRight: 20, marginLeft: 20 }}
+            disabled={!pinnedVertex}
+          >
+            Deselect <Tag minimal>Esc</Tag>
+          </Button>
+        )}
+      </HotkeysTarget2>
+
       <Drawer
         isOpen={settingsIsOpen}
         size={560}
@@ -89,11 +121,13 @@ export default function OntrologyExplorerControlDrawer(props: OntrologyExplorerC
             <p>
               Change the behavior of interactions with the graph, such as hovering and hiding parts of the interface
             </p>
+
             <Checkbox
               checked={highlightAncestors}
-              label={"Highlight ancestors of hovered cell (a)"}
+              label={"Highlight ancestors of hovered cell (hotkey a)"}
               onChange={handleHighlightAncestorChange}
             />
+
             <Checkbox checked={true} label="Show cell type force graph" onChange={() => {}} disabled />
             <Checkbox checked={true} label="Show sugiyama directed cyclic graph" onChange={() => {}} disabled />
             <h2> Interpretive overlays </h2>


### PR DESCRIPTION
To test: load app, click a node and press escape to clear, press a and check that it toggles highlight ancestor.