### PR TITLE
improving hull root selection and layout

### DIFF
--- a/src/components/OntologyExplorer/Controls.tsx
+++ b/src/components/OntologyExplorer/Controls.tsx
@@ -18,6 +18,7 @@ interface OntrologyExplorerControlDrawerProps {
   handleHighlightAncestorChange: any;
   sugiyamaIsOpen: boolean;
   sugiyamaIsEnabled: boolean;
+  handleDisplayHulls: any;
   handleSugiyamaOpen: any;
   minimumOutdegree: string;
   maximumOutdegree: string;
@@ -42,6 +43,7 @@ export default function OntrologyExplorerControlDrawer(props: OntrologyExplorerC
     handleMinOutdegreeChange,
     handleSugiyamaOpen,
     sugiyamaIsEnabled,
+    handleDisplayHulls
   } = props;
 
   const handleSettingsOpen = () => setSettingsIsOpen(true);
@@ -100,6 +102,14 @@ export default function OntrologyExplorerControlDrawer(props: OntrologyExplorerC
               handleSugiyamaOpen();
             },
           },
+          {
+            combo: "H",
+            global: true,
+            label: "Display hulls",
+            onKeyDown: () => {
+              handleDisplayHulls();
+            },
+          },              
         ]}
       >
         {({ handleKeyDown, handleKeyUp }) => (

--- a/src/components/OntologyExplorer/Controls.tsx
+++ b/src/components/OntologyExplorer/Controls.tsx
@@ -43,7 +43,7 @@ export default function OntrologyExplorerControlDrawer(props: OntrologyExplorerC
     handleMinOutdegreeChange,
     handleSugiyamaOpen,
     sugiyamaIsEnabled,
-    handleDisplayHulls
+    handleDisplayHulls,
   } = props;
 
   const handleSettingsOpen = () => setSettingsIsOpen(true);
@@ -109,7 +109,7 @@ export default function OntrologyExplorerControlDrawer(props: OntrologyExplorerC
             onKeyDown: () => {
               handleDisplayHulls();
             },
-          },              
+          },
         ]}
       >
         {({ handleKeyDown, handleKeyUp }) => (

--- a/src/components/OntologyExplorer/drawForce/hulls.ts
+++ b/src/components/OntologyExplorer/drawForce/hulls.ts
@@ -12,6 +12,7 @@ import { scaleLinear } from "d3-scale";
 export const drawHulls = (
   ontology: Ontology,
   nodes: any,
+  hullToNodes: Map<string,string[]>,  
   context: any,
   hullBorderColor: string,
   hullLabelColor: string,
@@ -25,7 +26,7 @@ export const drawHulls = (
    */
   //  ["CL:0002086", "CL:0002031", "CL:1000504"]
   hullRoots.forEach((vertex_id: string, i, arr) => {
-    drawHull(vertex_id, ontology, nodes, context, hullBorderColor, hullLabelColor, i, arr);
+    drawHull(vertex_id, ontology, nodes, hullToNodes, context, hullBorderColor, hullLabelColor, i, arr);
   });
 };
 
@@ -36,6 +37,7 @@ const drawHull = (
   vertex_id: string,
   ontology: Ontology,
   nodes: any,
+  hullToNodes: Map<string,string[]>,  
   context: any,
   hullBorderColor: string,
   hullLabelColor: string,
@@ -45,7 +47,6 @@ const drawHull = (
   /**
    * Retreive the vertex for its name and descendants
    */
-  const vertex: any = ontology.get(vertex_id);
 
   /**
    * Pick a color, and fade it
@@ -61,10 +62,7 @@ const drawHull = (
    * Filter the simulation's nodes that are descendants of the given vertex
    * Create the hull
    */
-  const filteredNodes = nodes.filter((node: any) => {
-    return vertex.children.includes(node.id) || node.id === vertex_id; // include self
-  });
-
+  const filteredNodes = nodes.filter((n: any)=> hullToNodes.get(vertex_id)?.includes(n.id) || n.id === vertex_id);
   let points: any = [];
 
   filteredNodes.forEach((node: any) => {
@@ -94,3 +92,22 @@ const drawHull = (
     context.stroke();
   }
 };
+
+export const getHullNodes = (
+  vertex_id: string,
+  ontology: Ontology,
+  nodes: any,
+): string[] => {
+  /**
+   * Get nodes belonging to a hull
+   */
+  const vertex: any = ontology.get(vertex_id);
+  if (vertex) {
+    const descendants = [...vertex.descendants];
+    return nodes.filter((node: any) => {
+      return descendants.includes(node.id) || node.id === vertex_id; // include self
+    });
+  } else {
+    return [];
+  }
+}

--- a/src/components/OntologyExplorer/drawForce/hulls.ts
+++ b/src/components/OntologyExplorer/drawForce/hulls.ts
@@ -12,7 +12,7 @@ import { scaleLinear } from "d3-scale";
 export const drawHulls = (
   ontology: Ontology,
   nodes: any,
-  hullToNodes: Map<string,string[]>,  
+  hullToNodes: Map<string, string[]>,
   context: any,
   hullBorderColor: string,
   hullLabelColor: string,
@@ -37,7 +37,7 @@ const drawHull = (
   vertex_id: string,
   ontology: Ontology,
   nodes: any,
-  hullToNodes: Map<string,string[]>,  
+  hullToNodes: Map<string, string[]>,
   context: any,
   hullBorderColor: string,
   hullLabelColor: string,
@@ -62,7 +62,7 @@ const drawHull = (
    * Filter the simulation's nodes that are descendants of the given vertex
    * Create the hull
    */
-  const filteredNodes = nodes.filter((n: any)=> hullToNodes.get(vertex_id)?.includes(n.id) || n.id === vertex_id);
+  const filteredNodes = nodes.filter((n: any) => hullToNodes.get(vertex_id)?.includes(n.id) || n.id === vertex_id);
   let points: any = [];
 
   filteredNodes.forEach((node: any) => {
@@ -93,11 +93,7 @@ const drawHull = (
   }
 };
 
-export const getHullNodes = (
-  vertex_id: string,
-  ontology: Ontology,
-  nodes: any,
-): string[] => {
+export const getHullNodes = (vertex_id: string, ontology: Ontology, nodes: any): string[] => {
   /**
    * Get nodes belonging to a hull
    */
@@ -110,4 +106,4 @@ export const getHullNodes = (
   } else {
     return [];
   }
-}
+};

--- a/src/components/OntologyExplorer/drawForce/index.ts
+++ b/src/components/OntologyExplorer/drawForce/index.ts
@@ -49,12 +49,15 @@ export interface DrawForceDagHighlightProps {
 export const drawForceDag = (
   nodes: OntologyVertexDatum[],
   links: SimulationLinkDatum<any>[],
+  hullToNodes: Map<string,string[]>,
   dagCanvasRef: React.RefObject<HTMLCanvasElement>,
   ontology: Ontology,
   setHoverNode: (node: OntologyVertexDatum | undefined) => void,
   setPinnedNode: (node: OntologyVertexDatum | undefined) => void,
   onForceSimulationEnd: any,
-  defaultHighlightProps: DrawForceDagHighlightProps = {}
+  defaultHighlightProps: DrawForceDagHighlightProps = {},
+  hullRoots: string[],
+  nodeToHullRoot: Map<string,string>
 ) => {
   if (!dagCanvasRef || !dagCanvasRef.current) return null;
 
@@ -75,40 +78,6 @@ export const drawForceDag = (
   const highlightProps: DrawForceDagHighlightProps = {
     ...defaultHighlightProps,
   };
-
-  /**
-   * Hull root vertices
-   */
-  const hullRoots: string[] = [
-    // hardcoded for the alpha, to be inferred with a heuristic
-    "CL:0002086",
-    "CL:0000542",
-    // "CL:0000540",
-    "CL:0000084",
-    "CL:0000236",
-    "CL:1000497",
-    "CL:0000039",
-    "CL:0000125",
-    "CL:0000101",
-    "CL:0000099",
-    "CL:0002563",
-    // "CL:0000988",
-    "CL:0000451",
-    "CL:0008007",
-    "CL:0002368",
-    // "CL:0000763",
-    "CL:0000163",
-    "CL:0000147",
-    "CL:0011026",
-    "CL:0000094",
-    "CL:0000100",
-    "CL:0001035",
-    "CL:0001065",
-    "CL:0000786",
-    "CL:1000854",
-    "CL:0000235",
-    "CL:0000210",
-  ];
 
   /**
    * Sizes
@@ -151,7 +120,6 @@ export const drawForceDag = (
   const initialRadius = 10;
   const graphDiameter = 2 * (initialRadius * Math.sqrt(0.5 + nodes.length));
   let canvasInvTransformMatrix: DOMMatrixReadOnly = dagCanvasRef.current.getContext("2d")!.getTransform().inverse();
-
   /**
    * Set up d3 force simulation
    */
@@ -161,9 +129,21 @@ export const drawForceDag = (
      */
     .force(
       "link",
-      forceLink(links).id((d: any) => d.id)
+      forceLink(links)
+      .id((d: any) => d.id)
+      .strength (function (d) {
+        const atLeastOneInHull = nodeToHullRoot.has(d.source.id) || nodeToHullRoot.has(d.target.id);
+        const inSameHull = nodeToHullRoot.get(d.source.id) === nodeToHullRoot.get(d.target.id);
+        const inNoHull = !(atLeastOneInHull || inSameHull);
+        let val;
+        if (highlightProps.hullsEnabled && atLeastOneInHull && inSameHull) val=1.0;
+        //else if(highlightProps.hullsEnabled && inNoHull) val=0.1;
+        //else if(highlightProps.hullsEnabled) val=0.1;
+        else val=0.1;
+        return val;
+      })
     )
-    .force("charge", forceManyBody())
+    .force("charge", forceManyBody()) 
     .force(
       "collision",
       forceCollide().radius((d: any) => {
@@ -256,7 +236,7 @@ export const drawForceDag = (
       /**
        * Draw hulls
        */
-      drawHulls(ontology, nodes, context, hullBorderColor, hullLabelColor, hullRoots);
+      drawHulls(ontology, nodes, hullToNodes, context, hullBorderColor, hullLabelColor, hullRoots);
 
       /**
        * Draw text on hull nodes

--- a/src/components/OntologyExplorer/drawForce/index.ts
+++ b/src/components/OntologyExplorer/drawForce/index.ts
@@ -49,7 +49,7 @@ export interface DrawForceDagHighlightProps {
 export const drawForceDag = (
   nodes: OntologyVertexDatum[],
   links: SimulationLinkDatum<any>[],
-  hullToNodes: Map<string,string[]>,
+  hullToNodes: Map<string, string[]>,
   dagCanvasRef: React.RefObject<HTMLCanvasElement>,
   ontology: Ontology,
   setHoverNode: (node: OntologyVertexDatum | undefined) => void,
@@ -57,7 +57,7 @@ export const drawForceDag = (
   onForceSimulationEnd: any,
   defaultHighlightProps: DrawForceDagHighlightProps = {},
   hullRoots: string[],
-  nodeToHullRoot: Map<string,string>
+  nodeToHullRoot: Map<string, string>
 ) => {
   if (!dagCanvasRef || !dagCanvasRef.current) return null;
 
@@ -130,20 +130,20 @@ export const drawForceDag = (
     .force(
       "link",
       forceLink(links)
-      .id((d: any) => d.id)
-      .strength (function (d) {
-        const atLeastOneInHull = nodeToHullRoot.has(d.source.id) || nodeToHullRoot.has(d.target.id);
-        const inSameHull = nodeToHullRoot.get(d.source.id) === nodeToHullRoot.get(d.target.id);
-        const inNoHull = !(atLeastOneInHull || inSameHull);
-        let val;
-        if (highlightProps.hullsEnabled && atLeastOneInHull && inSameHull) val=1.0;
-        //else if(highlightProps.hullsEnabled && inNoHull) val=0.1;
-        //else if(highlightProps.hullsEnabled) val=0.1;
-        else val=0.1;
-        return val;
-      })
+        .id((d: any) => d.id)
+        .strength(function (d) {
+          const atLeastOneInHull = nodeToHullRoot.has(d.source.id) || nodeToHullRoot.has(d.target.id);
+          const inSameHull = nodeToHullRoot.get(d.source.id) === nodeToHullRoot.get(d.target.id);
+          const inNoHull = !(atLeastOneInHull || inSameHull);
+          let val;
+          if (highlightProps.hullsEnabled && atLeastOneInHull && inSameHull) val = 1.0;
+          //else if(highlightProps.hullsEnabled && inNoHull) val=0.1;
+          //else if(highlightProps.hullsEnabled) val=0.1;
+          else val = 0.1;
+          return val;
+        })
     )
-    .force("charge", forceManyBody()) 
+    .force("charge", forceManyBody())
     .force(
       "collision",
       forceCollide().radius((d: any) => {

--- a/src/components/OntologyExplorer/index.tsx
+++ b/src/components/OntologyExplorer/index.tsx
@@ -12,6 +12,8 @@ import SearchSidebar, { SearchTerm, urlSearchParamsToSearchTerms, searchTermToUr
 import { OntologyId, OntologyTerm, OntologyPrefix, DatasetGraph } from "../../d";
 import { OntologyExplorerState, OntologyExplorerProps, OntologyVertexDatum, DagState, CreateDagProps } from "./types";
 import lruMemoize from "../../util/lruMemo";
+import { getHullNodes } from "./drawForce/hulls";
+
 import {
   ontologySubset,
   ontologyFilter,
@@ -53,6 +55,7 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
   const [dagState, setDagState] = useState<DagState | null>(null);
   const [forceCanvasHighlightProps, setForceCanvasHighlightProps] =
     useState<DrawForceDagHighlightProps>(defaultForceHightlightProps);
+    
   const [redrawCanvas, setRedrawCanvas] = useState<((p?: DrawForceDagHighlightProps) => void) | null>(null);
   const [sugiyamaIsOpen, setSugiyamaIsOpen] = useState<boolean>(false);
 
@@ -100,6 +103,8 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
   const { minimumOutdegree, maximumOutdegree } = dagCreateProps;
   const { hullsEnabled, highlightAncestors } = forceCanvasHighlightProps;
 
+  const heightMap = graph.heightMaps[ontoID];
+  const depthMap = graph.depthMaps[ontoID];  
   /*
    * memoized callback to navigate.
    */
@@ -131,22 +136,65 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
 
     Side effect: sets the render & simulation state.
     */
+
     if (dagState) {
-      const { nodes, links } = dagState;
+      const { nodes, links } = dagState;      
+
+      const nodeToHullRoot = new Map();
+      let flag = true;
+      let height = 7;
+      const allHullRoots: string[] = [];
+      while (flag && height >= 2) {
+        flag=false;
+        const hullRoots = [...heightMap].filter(([_, v]) => v === height ).map(([k,_])=>k) // get all hullRoots of a certain height
+        hullRoots.forEach((item)=>{ // for each root
+          const hullNodes = getHullNodes(item, ontology, nodes);
+          hullNodes.forEach((n: any)=>{ // for each node in root
+            if (!nodeToHullRoot.has(n.id)) { // if not already assigned a root
+              if (!allHullRoots.includes(item)) {
+                allHullRoots.push(item); // add root
+              }
+              nodeToHullRoot.set(n.id,item); // set the root.
+            }
+          })
+        })
+        try{
+          nodes.forEach((node)=>{ // for each node,
+            const id = node.id;
+            if (!nodeToHullRoot.has(id)) { // check if node doesn't have a root
+              flag=true; // set true
+              throw(Error);
+            }
+          })
+        } catch {}
+        height-=1;
+      }
+      const hullToNodes = new Map();
+      [...nodeToHullRoot].forEach((kv)=>{
+        const [k,v] = kv;
+        if (hullToNodes.has(v)) {
+          hullToNodes.get(v).push(k);
+        } else {
+          hullToNodes.set(v,[k]);
+        }
+      })
       const _redrawCanvas = drawForceDag(
         nodes,
         links,
+        hullToNodes,
         dagCanvasRef,
         ontology,
         (node?: OntologyVertexDatum) => setHoverNode(node),
         (node?: OntologyVertexDatum) => go(`../${node?.id ?? ""}`),
         () => setSimulationRunning(false),
-        defaultForceHightlightProps
+        {...defaultForceHightlightProps, hullsEnabled},
+        allHullRoots,
+        nodeToHullRoot
       );
       setRedrawCanvas(() => _redrawCanvas);
       setSimulationRunning(() => true);
     }
-  }, [ontology, dagState, dagCanvasRef, go]);
+  }, [ontology, dagState, dagCanvasRef, go, hullsEnabled, heightMap]);
 
   useEffect(() => {
     /*
@@ -253,6 +301,7 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
           dagState?.sugiyamaStratifyData && dagState?.sugiyamaStratifyData.length < sugiyamaRenderThreshold
         }
         handleSugiyamaOpen={handleSugiyamaOpen}
+        handleDisplayHulls={()=>setForceCanvasHighlightProps({...forceCanvasHighlightProps, hullsEnabled: !hullsEnabled})}        
         simulationRunning={simulationRunning}
         menubarHeight={menubarHeight}
         outdegreeCutoffNodes={minimumOutdegree}

--- a/src/components/OntologyExplorer/index.tsx
+++ b/src/components/OntologyExplorer/index.tsx
@@ -146,7 +146,12 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
       const allHullRoots: string[] = [];
       while (flag && height >= 2) {
         flag = false;
-        const hullRoots = [...heightMap].filter(([_, v]) => v === height).map(([k, _]) => k); // get all hullRoots of a certain height
+        const hullRoots = []; // get all hullRoots of a certain height
+        for (const [k, v] of heightMap) {
+          if (v === height) {
+            hullRoots.push(k);
+          }
+        }
         hullRoots.forEach((item) => {
           // for each root
           const hullNodes = getHullNodes(item, ontology, nodes);
@@ -161,22 +166,17 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
             }
           });
         });
-        try {
-          nodes.forEach((node) => {
-            // for each node,
-            const id = node.id;
-            if (!nodeToHullRoot.has(id)) {
-              // check if node doesn't have a root
-              flag = true; // set true
-              throw Error;
-            }
-          });
-        } catch {}
+        for (const node of nodes) {
+          const id = node.id;
+          if (!nodeToHullRoot.has(id)) {
+            flag = true;
+            break;
+          }
+        }
         height -= 1;
       }
       const hullToNodes = new Map();
-      [...nodeToHullRoot].forEach((kv) => {
-        const [k, v] = kv;
+      nodeToHullRoot.forEach((v, k) => {
         if (hullToNodes.has(v)) {
           hullToNodes.get(v).push(k);
         } else {

--- a/src/components/OntologyExplorer/index.tsx
+++ b/src/components/OntologyExplorer/index.tsx
@@ -55,7 +55,7 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
   const [dagState, setDagState] = useState<DagState | null>(null);
   const [forceCanvasHighlightProps, setForceCanvasHighlightProps] =
     useState<DrawForceDagHighlightProps>(defaultForceHightlightProps);
-    
+
   const [redrawCanvas, setRedrawCanvas] = useState<((p?: DrawForceDagHighlightProps) => void) | null>(null);
   const [sugiyamaIsOpen, setSugiyamaIsOpen] = useState<boolean>(false);
 
@@ -104,7 +104,7 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
   const { hullsEnabled, highlightAncestors } = forceCanvasHighlightProps;
 
   const heightMap = graph.heightMaps[ontoID];
-  const depthMap = graph.depthMaps[ontoID];  
+  const depthMap = graph.depthMaps[ontoID];
   /*
    * memoized callback to navigate.
    */
@@ -138,46 +138,51 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
     */
 
     if (dagState) {
-      const { nodes, links } = dagState;      
+      const { nodes, links } = dagState;
 
       const nodeToHullRoot = new Map();
       let flag = true;
       let height = 7;
       const allHullRoots: string[] = [];
       while (flag && height >= 2) {
-        flag=false;
-        const hullRoots = [...heightMap].filter(([_, v]) => v === height ).map(([k,_])=>k) // get all hullRoots of a certain height
-        hullRoots.forEach((item)=>{ // for each root
+        flag = false;
+        const hullRoots = [...heightMap].filter(([_, v]) => v === height).map(([k, _]) => k); // get all hullRoots of a certain height
+        hullRoots.forEach((item) => {
+          // for each root
           const hullNodes = getHullNodes(item, ontology, nodes);
-          hullNodes.forEach((n: any)=>{ // for each node in root
-            if (!nodeToHullRoot.has(n.id)) { // if not already assigned a root
+          hullNodes.forEach((n: any) => {
+            // for each node in root
+            if (!nodeToHullRoot.has(n.id)) {
+              // if not already assigned a root
               if (!allHullRoots.includes(item)) {
                 allHullRoots.push(item); // add root
               }
-              nodeToHullRoot.set(n.id,item); // set the root.
+              nodeToHullRoot.set(n.id, item); // set the root.
             }
-          })
-        })
-        try{
-          nodes.forEach((node)=>{ // for each node,
+          });
+        });
+        try {
+          nodes.forEach((node) => {
+            // for each node,
             const id = node.id;
-            if (!nodeToHullRoot.has(id)) { // check if node doesn't have a root
-              flag=true; // set true
-              throw(Error);
+            if (!nodeToHullRoot.has(id)) {
+              // check if node doesn't have a root
+              flag = true; // set true
+              throw Error;
             }
-          })
+          });
         } catch {}
-        height-=1;
+        height -= 1;
       }
       const hullToNodes = new Map();
-      [...nodeToHullRoot].forEach((kv)=>{
-        const [k,v] = kv;
+      [...nodeToHullRoot].forEach((kv) => {
+        const [k, v] = kv;
         if (hullToNodes.has(v)) {
           hullToNodes.get(v).push(k);
         } else {
-          hullToNodes.set(v,[k]);
+          hullToNodes.set(v, [k]);
         }
-      })
+      });
       const _redrawCanvas = drawForceDag(
         nodes,
         links,
@@ -187,7 +192,7 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
         (node?: OntologyVertexDatum) => setHoverNode(node),
         (node?: OntologyVertexDatum) => go(`../${node?.id ?? ""}`),
         () => setSimulationRunning(false),
-        {...defaultForceHightlightProps, hullsEnabled},
+        { ...defaultForceHightlightProps, hullsEnabled },
         allHullRoots,
         nodeToHullRoot
       );
@@ -301,7 +306,9 @@ export default function OntologyExplorer({ graph }: OntologyExplorerProps): JSX.
           dagState?.sugiyamaStratifyData && dagState?.sugiyamaStratifyData.length < sugiyamaRenderThreshold
         }
         handleSugiyamaOpen={handleSugiyamaOpen}
-        handleDisplayHulls={()=>setForceCanvasHighlightProps({...forceCanvasHighlightProps, hullsEnabled: !hullsEnabled})}        
+        handleDisplayHulls={() =>
+          setForceCanvasHighlightProps({ ...forceCanvasHighlightProps, hullsEnabled: !hullsEnabled })
+        }
         simulationRunning={simulationRunning}
         menubarHeight={menubarHeight}
         outdegreeCutoffNodes={minimumOutdegree}

--- a/src/d.ts
+++ b/src/d.ts
@@ -35,8 +35,8 @@ export interface DatasetGraph {
   master_ontology_uri: string; // source of master (full) ontology
   lattice_uri: string; // source of xref lattice data
   ontologies: Record<OntologyPrefix, Ontology>;
-  depthMaps: Record<OntologyPrefix, Map<string,number>>;
-  heightMaps: Record<OntologyPrefix, Map<string,number>>;  
+  depthMaps: Record<OntologyPrefix, Map<string, number>>;
+  heightMaps: Record<OntologyPrefix, Map<string, number>>;
 }
 
 export interface EBIOlsTerm {

--- a/src/d.ts
+++ b/src/d.ts
@@ -16,6 +16,8 @@ export interface OntologyTerm {
   have_part: OntologyId[];
   xref: OntologyId[]; // cross-ref & related terms - in this and other ontologies
   synonyms: string[];
+  depth: number; // for a control to prune nodes by depths
+  height: number; // for automatically selecting hulls
 
   // Statistics & information from the dataset
   n_cells: number; // number of cells labelled with this term
@@ -33,6 +35,8 @@ export interface DatasetGraph {
   master_ontology_uri: string; // source of master (full) ontology
   lattice_uri: string; // source of xref lattice data
   ontologies: Record<OntologyPrefix, Ontology>;
+  depthMaps: Record<OntologyPrefix, Map<string,number>>;
+  heightMaps: Record<OntologyPrefix, Map<string,number>>;  
 }
 
 export interface EBIOlsTerm {

--- a/src/util/loadDatasetGraph.ts
+++ b/src/util/loadDatasetGraph.ts
@@ -49,17 +49,11 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
       ])
     ),
     depthMaps: Object.fromEntries(
-      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [
-        key,
-        new Map<string,number>(),
-      ])
+      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [key, new Map<string, number>()])
     ),
     heightMaps: Object.fromEntries(
-      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [
-        key,
-        new Map<string,number>(),
-      ])
-    )    
+      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [key, new Map<string, number>()])
+    ),
   };
 
   // Add ID, children, ancestors, descendants and xref
@@ -67,7 +61,7 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
   // CAUTION: relations (eg, children) are accumulated incrementally, and only
   // the `parent` is correct prior to the completion of this loop.
   //
-  for (const [prefix,ontology] of Object.entries(datasetGraph.ontologies)) {
+  for (const [prefix, ontology] of Object.entries(datasetGraph.ontologies)) {
     for (const [termId, term] of ontology.entries()) {
       // set all defaults
       term.id = termId;
@@ -82,7 +76,7 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
       term.derives_from = term.derives_from || [];
       if (term.n_cells === undefined) term.n_cells = 0;
       if (term.depth === undefined) term.depth = -1;
-      if (term.height === undefined) term.height = -1;            
+      if (term.height === undefined) term.height = -1;
     }
 
     for (const term of ontology.values()) {
@@ -99,14 +93,14 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
     for (const term of ontology.values()) {
       term.in_use = !!term.n_cells || [...term.descendants].some((id) => ontology.get(id)!.n_cells > 0);
     }
-    const rootKeys = [...ontology].filter(([_,v])=>v.parents?.length===0).map(([k,_])=>k);    
-    rootKeys.forEach((key)=>{
-      const rootTerm = ontology.get(key);  
+    const rootKeys = [...ontology].filter(([_, v]) => v.parents?.length === 0).map(([k, _]) => k);
+    rootKeys.forEach((key) => {
+      const rootTerm = ontology.get(key);
       if (rootTerm) {
-        calcDepthBFS(ontology, rootTerm, datasetGraph.depthMaps[prefix])
-        calcHeightDFS(ontology, rootTerm, datasetGraph.heightMaps[prefix])        
+        calcDepthBFS(ontology, rootTerm, datasetGraph.depthMaps[prefix]);
+        calcHeightDFS(ontology, rootTerm, datasetGraph.heightMaps[prefix]);
       }
-    })    
+    });
   }
 
   return datasetGraph;
@@ -119,13 +113,13 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
  * @param term
  * @param depthMap
  */
- function calcDepthBFS(ontology: Ontology, term: OntologyTerm, depthMap: Map<string,number>): void {
+function calcDepthBFS(ontology: Ontology, term: OntologyTerm, depthMap: Map<string, number>): void {
   const stack = [...term.children];
   const depthStack: number[] = new Array(stack.length);
   depthStack.fill(1);
-  depthMap.set(term.id,0);
-  if (term.depth===-1) term.depth=0;
-  while ( stack.length > 0 ) {
+  depthMap.set(term.id, 0);
+  if (term.depth === -1) term.depth = 0;
+  while (stack.length > 0) {
     const id = stack.pop();
     const depth = depthStack.pop();
     if (id && depth) {
@@ -133,10 +127,10 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
       if (newTerm) {
         if (newTerm.depth === -1) newTerm.depth = depth;
         const newDepths = new Array(newTerm.children.length);
-        newDepths.fill(depth+1);
-        stack.push(...newTerm.children);        
+        newDepths.fill(depth + 1);
+        stack.push(...newTerm.children);
         depthStack.push(...newDepths);
-        if (!depthMap.has(newTerm.id)) depthMap.set(newTerm.id, depth)
+        if (!depthMap.has(newTerm.id)) depthMap.set(newTerm.id, depth);
       }
     }
   }
@@ -149,26 +143,25 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
  * @param term
  * @param heightMap
  */
-function calcHeightDFS(ontology: Ontology, term: OntologyTerm, heightMap: Map<string,number>): number {
+function calcHeightDFS(ontology: Ontology, term: OntologyTerm, heightMap: Map<string, number>): number {
   const heights = [];
   for (const child of term.children) {
     const childTerm = ontology.get(child);
     if (childTerm) {
-      heights.push(calcHeightDFS(ontology, childTerm, heightMap)+1);  
+      heights.push(calcHeightDFS(ontology, childTerm, heightMap) + 1);
     }
   }
   const val = heights.length > 0 ? Math.max(...heights) : 0;
   if (heightMap.has(term.id)) {
-    const updatedVal = Math.max(heightMap.get(term.id) ?? 0,val);
-    heightMap.set(term.id, updatedVal)
+    const updatedVal = Math.max(heightMap.get(term.id) ?? 0, val);
+    heightMap.set(term.id, updatedVal);
     term.height = updatedVal;
   } else {
-    heightMap.set(term.id, val)
+    heightMap.set(term.id, val);
     term.height = val;
   }
 
   return val;
-
 }
 /**
  * Add our ID to our immediate parent's children[].

--- a/src/util/loadDatasetGraph.ts
+++ b/src/util/loadDatasetGraph.ts
@@ -48,6 +48,18 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
         new Map(Object.entries(rawGraph.ontologies[key])),
       ])
     ),
+    depthMaps: Object.fromEntries(
+      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [
+        key,
+        new Map<string,number>(),
+      ])
+    ),
+    heightMaps: Object.fromEntries(
+      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [
+        key,
+        new Map<string,number>(),
+      ])
+    )    
   };
 
   // Add ID, children, ancestors, descendants and xref
@@ -55,7 +67,7 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
   // CAUTION: relations (eg, children) are accumulated incrementally, and only
   // the `parent` is correct prior to the completion of this loop.
   //
-  for (const ontology of Object.values(datasetGraph.ontologies)) {
+  for (const [prefix,ontology] of Object.entries(datasetGraph.ontologies)) {
     for (const [termId, term] of ontology.entries()) {
       // set all defaults
       term.id = termId;
@@ -69,6 +81,8 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
       term.develops_from = term.develops_from || [];
       term.derives_from = term.derives_from || [];
       if (term.n_cells === undefined) term.n_cells = 0;
+      if (term.depth === undefined) term.depth = -1;
+      if (term.height === undefined) term.height = -1;            
     }
 
     for (const term of ontology.values()) {
@@ -85,11 +99,77 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
     for (const term of ontology.values()) {
       term.in_use = !!term.n_cells || [...term.descendants].some((id) => ontology.get(id)!.n_cells > 0);
     }
+    const rootKeys = [...ontology].filter(([_,v])=>v.parents?.length===0).map(([k,_])=>k);    
+    rootKeys.forEach((key)=>{
+      const rootTerm = ontology.get(key);  
+      if (rootTerm) {
+        calcDepthBFS(ontology, rootTerm, datasetGraph.depthMaps[prefix])
+        calcHeightDFS(ontology, rootTerm, datasetGraph.heightMaps[prefix])        
+      }
+    })    
   }
 
   return datasetGraph;
 }
 
+/**
+ * Calculate depth of a node in the ontology
+ *
+ * @param ontology
+ * @param term
+ * @param depthMap
+ */
+ function calcDepthBFS(ontology: Ontology, term: OntologyTerm, depthMap: Map<string,number>): void {
+  const stack = [...term.children];
+  const depthStack: number[] = new Array(stack.length);
+  depthStack.fill(1);
+  depthMap.set(term.id,0);
+  if (term.depth===-1) term.depth=0;
+  while ( stack.length > 0 ) {
+    const id = stack.pop();
+    const depth = depthStack.pop();
+    if (id && depth) {
+      const newTerm = ontology.get(id);
+      if (newTerm) {
+        if (newTerm.depth === -1) newTerm.depth = depth;
+        const newDepths = new Array(newTerm.children.length);
+        newDepths.fill(depth+1);
+        stack.push(...newTerm.children);        
+        depthStack.push(...newDepths);
+        if (!depthMap.has(newTerm.id)) depthMap.set(newTerm.id, depth)
+      }
+    }
+  }
+}
+
+/**
+ * Calculate height of a node in the ontology from the furthest leaf
+ *
+ * @param ontology
+ * @param term
+ * @param heightMap
+ */
+function calcHeightDFS(ontology: Ontology, term: OntologyTerm, heightMap: Map<string,number>): number {
+  const heights = [];
+  for (const child of term.children) {
+    const childTerm = ontology.get(child);
+    if (childTerm) {
+      heights.push(calcHeightDFS(ontology, childTerm, heightMap)+1);  
+    }
+  }
+  const val = heights.length > 0 ? Math.max(...heights) : 0;
+  if (heightMap.has(term.id)) {
+    const updatedVal = Math.max(heightMap.get(term.id) ?? 0,val);
+    heightMap.set(term.id, updatedVal)
+    term.height = updatedVal;
+  } else {
+    heightMap.set(term.id, val)
+    term.height = val;
+  }
+
+  return val;
+
+}
 /**
  * Add our ID to our immediate parent's children[].
  *


### PR DESCRIPTION
Changes:
1) Hull roots are no longer hardcoded
2) Hulls span all descendants of roots instead of their direct children 
3) "H" hotkey toggles hull display
4) Link strengths between nodes within a hull are set to 1.0 (max strength).

### Automatic hull root selection (AKA heuristic trash)
Pseudocode:
```
1) Select all nodes with height (max distance from a node to its leaves) = 7. These nodes are roots.
2) Assign all descendants of each root to that hull
3) If height > 2 and there are unassigned nodes, decrement height and go to (1).
```
The idea is to select roots that result in clades with similar depths (variable widths). It might be nice to select for roots that give similar aspect ratios instead. Regardless, I believe this is a step in the right direction.

<img width="607" alt="image" src="https://user-images.githubusercontent.com/16548075/179632356-0e673c03-4119-404d-872d-c4406c57308a.png">
