### PR TITLE
add node depths and heights to the ontology

### DIFF
--- a/src/d.ts
+++ b/src/d.ts
@@ -35,8 +35,8 @@ export interface DatasetGraph {
   master_ontology_uri: string; // source of master (full) ontology
   lattice_uri: string; // source of xref lattice data
   ontologies: Record<OntologyPrefix, Ontology>;
-  depthMaps: Record<OntologyPrefix, Map<string,number>>;
-  heightMaps: Record<OntologyPrefix, Map<string,number>>;  
+  depthMaps: Record<OntologyPrefix, Map<string, number>>;
+  heightMaps: Record<OntologyPrefix, Map<string, number>>;
 }
 
 export interface EBIOlsTerm {

--- a/src/d.ts
+++ b/src/d.ts
@@ -16,6 +16,8 @@ export interface OntologyTerm {
   have_part: OntologyId[];
   xref: OntologyId[]; // cross-ref & related terms - in this and other ontologies
   synonyms: string[];
+  depth: number; // for a control to prune nodes by depths
+  height: number; // for automatically selecting hulls
 
   // Statistics & information from the dataset
   n_cells: number; // number of cells labelled with this term
@@ -33,6 +35,8 @@ export interface DatasetGraph {
   master_ontology_uri: string; // source of master (full) ontology
   lattice_uri: string; // source of xref lattice data
   ontologies: Record<OntologyPrefix, Ontology>;
+  depthMaps: Record<OntologyPrefix, Map<string,number>>;
+  heightMaps: Record<OntologyPrefix, Map<string,number>>;  
 }
 
 export interface EBIOlsTerm {

--- a/src/util/loadDatasetGraph.ts
+++ b/src/util/loadDatasetGraph.ts
@@ -151,17 +151,17 @@ function calcHeightDFS(ontology: Ontology, term: OntologyTerm, heightMap: Map<st
       heights.push(calcHeightDFS(ontology, childTerm, heightMap) + 1);
     }
   }
-  const val = heights.length > 0 ? Math.max(...heights) : 0;
+  const maxHeight = heights.length > 0 ? Math.max(...heights) : 0;
   if (heightMap.has(term.id)) {
-    const updatedVal = Math.max(heightMap.get(term.id) ?? 0, val);
+    const updatedVal = Math.max(heightMap.get(term.id) ?? 0, maxHeight);
     heightMap.set(term.id, updatedVal);
     term.height = updatedVal;
   } else {
-    heightMap.set(term.id, val);
-    term.height = val;
+    heightMap.set(term.id, maxHeight);
+    term.height = maxHeight;
   }
 
-  return val;
+  return maxHeight;
 }
 /**
  * Add our ID to our immediate parent's children[].

--- a/src/util/loadDatasetGraph.ts
+++ b/src/util/loadDatasetGraph.ts
@@ -49,17 +49,11 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
       ])
     ),
     depthMaps: Object.fromEntries(
-      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [
-        key,
-        new Map<string,number>(),
-      ])
+      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [key, new Map<string, number>()])
     ),
     heightMaps: Object.fromEntries(
-      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [
-        key,
-        new Map<string,number>(),
-      ])
-    )    
+      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [key, new Map<string, number>()])
+    ),
   };
 
   // Add ID, children, ancestors, descendants and xref
@@ -67,7 +61,7 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
   // CAUTION: relations (eg, children) are accumulated incrementally, and only
   // the `parent` is correct prior to the completion of this loop.
   //
-  for (const [prefix,ontology] of Object.entries(datasetGraph.ontologies)) {
+  for (const [prefix, ontology] of Object.entries(datasetGraph.ontologies)) {
     for (const [termId, term] of ontology.entries()) {
       // set all defaults
       term.id = termId;
@@ -82,7 +76,7 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
       term.derives_from = term.derives_from || [];
       if (term.n_cells === undefined) term.n_cells = 0;
       if (term.depth === undefined) term.depth = -1;
-      if (term.height === undefined) term.height = -1;            
+      if (term.height === undefined) term.height = -1;
     }
 
     for (const term of ontology.values()) {
@@ -99,14 +93,14 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
     for (const term of ontology.values()) {
       term.in_use = !!term.n_cells || [...term.descendants].some((id) => ontology.get(id)!.n_cells > 0);
     }
-    const rootKeys = [...ontology].filter(([_,v])=>v.parents?.length===0).map(([k,_])=>k);    
-    rootKeys.forEach((key)=>{
-      const rootTerm = ontology.get(key);  
+    const rootKeys = [...ontology].filter(([_, v]) => v.parents?.length === 0).map(([k, _]) => k);
+    rootKeys.forEach((key) => {
+      const rootTerm = ontology.get(key);
       if (rootTerm) {
-        calcDepthBFS(ontology, rootTerm, datasetGraph.depthMaps[prefix])
-        calcHeightDFS(ontology, rootTerm, datasetGraph.heightMaps[prefix])        
+        calcDepthBFS(ontology, rootTerm, datasetGraph.depthMaps[prefix]);
+        calcHeightDFS(ontology, rootTerm, datasetGraph.heightMaps[prefix]);
       }
-    })    
+    });
   }
 
   return datasetGraph;
@@ -119,13 +113,13 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
  * @param term
  * @param depthMap
  */
- function calcDepthBFS(ontology: Ontology, term: OntologyTerm, depthMap: Map<string,number>): void {
+function calcDepthBFS(ontology: Ontology, term: OntologyTerm, depthMap: Map<string, number>): void {
   const stack = [...term.children];
   const depthStack: number[] = new Array(stack.length);
   depthStack.fill(1);
-  depthMap.set(term.id,0);
-  if (term.depth===-1) term.depth=0;
-  while ( stack.length > 0 ) {
+  depthMap.set(term.id, 0);
+  if (term.depth === -1) term.depth = 0;
+  while (stack.length > 0) {
     const id = stack.pop();
     const depth = depthStack.pop();
     if (id && depth) {
@@ -133,10 +127,10 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
       if (newTerm) {
         if (newTerm.depth === -1) newTerm.depth = depth;
         const newDepths = new Array(newTerm.children.length);
-        newDepths.fill(depth+1);
-        stack.push(...newTerm.children);        
+        newDepths.fill(depth + 1);
+        stack.push(...newTerm.children);
         depthStack.push(...newDepths);
-        if (!depthMap.has(newTerm.id)) depthMap.set(newTerm.id, depth)
+        if (!depthMap.has(newTerm.id)) depthMap.set(newTerm.id, depth);
       }
     }
   }
@@ -149,26 +143,25 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
  * @param term
  * @param heightMap
  */
-function calcHeightDFS(ontology: Ontology, term: OntologyTerm, heightMap: Map<string,number>): number {
+function calcHeightDFS(ontology: Ontology, term: OntologyTerm, heightMap: Map<string, number>): number {
   const heights = [];
   for (const child of term.children) {
     const childTerm = ontology.get(child);
     if (childTerm) {
-      heights.push(calcHeightDFS(ontology, childTerm, heightMap)+1);  
+      heights.push(calcHeightDFS(ontology, childTerm, heightMap) + 1);
     }
   }
   const val = heights.length > 0 ? Math.max(...heights) : 0;
   if (heightMap.has(term.id)) {
-    const updatedVal = Math.max(heightMap.get(term.id) ?? 0,val);
-    heightMap.set(term.id, updatedVal)
+    const updatedVal = Math.max(heightMap.get(term.id) ?? 0, val);
+    heightMap.set(term.id, updatedVal);
     term.height = updatedVal;
   } else {
-    heightMap.set(term.id, val)
+    heightMap.set(term.id, val);
     term.height = val;
   }
 
   return val;
-
 }
 /**
  * Add our ID to our immediate parent's children[].

--- a/src/util/loadDatasetGraph.ts
+++ b/src/util/loadDatasetGraph.ts
@@ -48,6 +48,18 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
         new Map(Object.entries(rawGraph.ontologies[key])),
       ])
     ),
+    depthMaps: Object.fromEntries(
+      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [
+        key,
+        new Map<string,number>(),
+      ])
+    ),
+    heightMaps: Object.fromEntries(
+      Object.keys(rawGraph.ontologies).map((key: OntologyPrefix) => [
+        key,
+        new Map<string,number>(),
+      ])
+    )    
   };
 
   // Add ID, children, ancestors, descendants and xref
@@ -55,7 +67,7 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
   // CAUTION: relations (eg, children) are accumulated incrementally, and only
   // the `parent` is correct prior to the completion of this loop.
   //
-  for (const ontology of Object.values(datasetGraph.ontologies)) {
+  for (const [prefix,ontology] of Object.entries(datasetGraph.ontologies)) {
     for (const [termId, term] of ontology.entries()) {
       // set all defaults
       term.id = termId;
@@ -69,6 +81,8 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
       term.develops_from = term.develops_from || [];
       term.derives_from = term.derives_from || [];
       if (term.n_cells === undefined) term.n_cells = 0;
+      if (term.depth === undefined) term.depth = -1;
+      if (term.height === undefined) term.height = -1;            
     }
 
     for (const term of ontology.values()) {
@@ -85,11 +99,77 @@ function createDatasetGraph(rawGraph: any): DatasetGraph {
     for (const term of ontology.values()) {
       term.in_use = !!term.n_cells || [...term.descendants].some((id) => ontology.get(id)!.n_cells > 0);
     }
+    const rootKeys = [...ontology].filter(([_,v])=>v.parents?.length===0).map(([k,_])=>k);    
+    rootKeys.forEach((key)=>{
+      const rootTerm = ontology.get(key);  
+      if (rootTerm) {
+        calcDepthBFS(ontology, rootTerm, datasetGraph.depthMaps[prefix])
+        calcHeightDFS(ontology, rootTerm, datasetGraph.heightMaps[prefix])        
+      }
+    })    
   }
 
   return datasetGraph;
 }
 
+/**
+ * Calculate depth of a node in the ontology
+ *
+ * @param ontology
+ * @param term
+ * @param depthMap
+ */
+ function calcDepthBFS(ontology: Ontology, term: OntologyTerm, depthMap: Map<string,number>): void {
+  const stack = [...term.children];
+  const depthStack: number[] = new Array(stack.length);
+  depthStack.fill(1);
+  depthMap.set(term.id,0);
+  if (term.depth===-1) term.depth=0;
+  while ( stack.length > 0 ) {
+    const id = stack.pop();
+    const depth = depthStack.pop();
+    if (id && depth) {
+      const newTerm = ontology.get(id);
+      if (newTerm) {
+        if (newTerm.depth === -1) newTerm.depth = depth;
+        const newDepths = new Array(newTerm.children.length);
+        newDepths.fill(depth+1);
+        stack.push(...newTerm.children);        
+        depthStack.push(...newDepths);
+        if (!depthMap.has(newTerm.id)) depthMap.set(newTerm.id, depth)
+      }
+    }
+  }
+}
+
+/**
+ * Calculate height of a node in the ontology from the furthest leaf
+ *
+ * @param ontology
+ * @param term
+ * @param heightMap
+ */
+function calcHeightDFS(ontology: Ontology, term: OntologyTerm, heightMap: Map<string,number>): number {
+  const heights = [];
+  for (const child of term.children) {
+    const childTerm = ontology.get(child);
+    if (childTerm) {
+      heights.push(calcHeightDFS(ontology, childTerm, heightMap)+1);  
+    }
+  }
+  const val = heights.length > 0 ? Math.max(...heights) : 0;
+  if (heightMap.has(term.id)) {
+    const updatedVal = Math.max(heightMap.get(term.id) ?? 0,val);
+    heightMap.set(term.id, updatedVal)
+    term.height = updatedVal;
+  } else {
+    heightMap.set(term.id, val)
+    term.height = val;
+  }
+
+  return val;
+
+}
 /**
  * Add our ID to our immediate parent's children[].
  *


### PR DESCRIPTION
The code isolated in this PR is used in PRs #128 and #130. 

Here, I:
1) create two maps embedded in DatasetGraph, mapping ontology node ID to their respective depths/heights.
2) add the depths and heights to each of the OntologyVertex objects directly

Depth is the shortest distance to the root node. This is used for the the pruning nodes by depths feature in #130.
Height is the furthest distance from any of a node's leaves. This is used to automatically select hulls in #128.