### PR TITLE
fix: worked out network routing for app

### DIFF
--- a/.happy/terraform/envs/rdev/main.tf
+++ b/.happy/terraform/envs/rdev/main.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source              = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=main"
+  source              = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=happy-stack-eks-v3.1.0"
   happy_config_secret = var.happy_config_secret
   image_tag           = var.image_tag
   happymeta_          = var.happymeta_
@@ -8,15 +8,17 @@ module "stack" {
   deployment_stage    = "rdev"
   stack_prefix        = "/${var.stack_name}"
   k8s_namespace       = "jheath-rdev-happy-happy-env"
+  routing_method = "CONTEXT"
   services = {
     frontend = {
       name                = "frontend",
       desired_count       = 1,
       port                = 3000,
-      memory              = "500Mi"
-      cpu                 = "250m"
+      memory              = "1G"
+      cpu                 = "1.0"
       health_check_path   = "/",
-      service_type        = "INTERNAL"
+      service_type        = "EXTERNAL"
+      path = "/*"
     },
     backend = {
       name                = "backend",
@@ -24,8 +26,11 @@ module "stack" {
       port                = 5000,
       memory              = "500Mi"
       cpu                 = "250m"
-      health_check_path   = "/api",
-      service_type        = "INTERNAL"
+      health_check_path   = "/api/health",
+      service_type        = "EXTERNAL"
+      path = "/api*"
+            priority                         = 1
+
     }
   }
   tasks = {

--- a/.happy/terraform/envs/rdev/versions.tf
+++ b/.happy/terraform/envs/rdev/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = ">= 2.16"
     }
     datadog = {
-      source = "datadog/datadog"
+      source  = "datadog/datadog"
       version = ">= 3.20.0"
     }
   }

--- a/server/app.py
+++ b/server/app.py
@@ -14,13 +14,13 @@ app.config['CORS_HEADERS'] = 'Content-Type'
 # https://github.com/chanzuckerberg/cell-census/releases/tag/v0.4.0
 census = cell_census.open_soma()
 
-@app.route('/')
+@app.route('/api')
 def hello_world():
     return '<h1>This is the "/" route for the python backend for cellxgene-ontology</h1>'
 
 # this route will be hit from a react app running on port 3000
 # it will return a json object
-@app.route('/api')
+@app.route('/api/health')
 @cross_origin(origin='localhost',headers=['Content- Type','Authorization'])
 def api():
     return {'hello': 'world'}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,8 +28,8 @@ function App({ basename }: { basename: string }) {
   // fetch json at port 5000/api
   useEffect(() => {
     const initState = async () => {
-      const response = await fetch("http://localhost:5000/api");
-      const data = await response.json();
+      const response = await fetch("/api");
+      const data = await response.text();
       console.log(data);
     };
 

--- a/src/util/apiPrefix.ts
+++ b/src/util/apiPrefix.ts
@@ -1,5 +1,5 @@
 import isProd from "./isProd";
 
-const apiPrefix = isProd ? "https://cellxgene.cziscience.com" : "http://127.0.0.1:5000/api";
+const apiPrefix = isProd ? "https://cellxgene.cziscience.com" : "/api";
 
 export default apiPrefix;


### PR DESCRIPTION
I switched the happy application from domain-based routing to context (path)-based routing. What this does is it puts both the frontend and backend service behind the same domain and that depending on what path you go to, it routes to the proper service. This way you don't have to worry about CORS or knowing the domain name of prod/staging/etc. You just have to make a request to the domain.

As an exercise, I also updated the service type to "EXTERNAL" to bypass OIDC authentication for now. If this is how you'd like the application to run, we can work on where to actually put this, but for now just assume this is what it would look like in a production environment.